### PR TITLE
Install vhd-tool to libexec instead of bin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ dist/setup: vhd-tool.obuild
 
 .PHONY: install
 install: build
-	install -D -m 755 dist/build/vhd-tool/vhd-tool ${BINDIR}/vhd-tool
+	install -D -m 755 dist/build/vhd-tool/vhd-tool ${LIBEXECDIR}/vhd-tool
 	install -D -m 755 dist/build/sparse_dd/sparse_dd ${LIBEXECDIR}/sparse_dd
 	install -D -m 644 src/sparse_dd.conf ${ETCDIR}/sparse_dd.conf
 


### PR DESCRIPTION
Dave recommended that we install this tool to libexec rather than bin, since it's new and we don't want to encourage people to use it on their own just yet.

Signed-off-by: Mike McClurg <mike.mcclurg@citrix.com>