### PR TITLE
CA-208537: vdi-copy between local SRs proposes unwanted ciphers

### DIFF
--- a/src/impl.ml
+++ b/src/impl.ml
@@ -664,7 +664,7 @@ let make_stream common source relative_to source_format destination_format =
     Raw_input.raw t
   | _, _ -> assert false
 
-let write_stream common s destination source_protocol destination_protocol prezeroed progress tar_filename_prefix = 
+let write_stream common s destination source_protocol destination_protocol prezeroed progress tar_filename_prefix ssl_legacy good_ciphersuites legacy_ciphersuites = 
   endpoint_of_string destination >>= fun endpoint ->
   let use_ssl = match endpoint with Https _ -> true | _ -> false in
   ( match endpoint with
@@ -698,7 +698,7 @@ let write_stream common s destination source_protocol destination_protocol preze
       Lwt_unix.connect sock sockaddr >>= fun () ->
 
       let open Cohttp in
-      ( if use_ssl then Channels.of_ssl_fd sock else Channels.of_raw_fd sock ) >>= fun c ->
+      ( if use_ssl then Channels.of_ssl_fd sock ssl_legacy good_ciphersuites legacy_ciphersuites else Channels.of_raw_fd sock ) >>= fun c ->
   
       let module Request = Request.Make(Cohttp_unbuffered_io) in
       let module Response = Response.Make(Cohttp_unbuffered_io) in
@@ -783,7 +783,7 @@ let write_stream common s destination source_protocol destination_protocol preze
 
 let stream_t common args ?(progress = no_progress_bar) () =
   make_stream common args.StreamCommon.source args.StreamCommon.relative_to args.StreamCommon.source_format args.StreamCommon.destination_format >>= fun s ->
-  write_stream common s args.StreamCommon.destination args.StreamCommon.source_protocol args.StreamCommon.destination_protocol args.StreamCommon.prezeroed progress args.StreamCommon.tar_filename_prefix
+  write_stream common s args.StreamCommon.destination args.StreamCommon.source_protocol args.StreamCommon.destination_protocol args.StreamCommon.prezeroed progress args.StreamCommon.tar_filename_prefix args.StreamCommon.ssl_legacy args.StreamCommon.good_ciphersuites args.StreamCommon.legacy_ciphersuites
 
 let stream common args =
   try

--- a/src/main.ml
+++ b/src/main.ml
@@ -162,6 +162,18 @@ let tar_filename_prefix =
   let doc = "Filename prefix for tar/sha disk blocks" in
   Arg.(value & opt (some string) None & info ["tar-filename-prefix"] ~doc)
 
+let ssl_legacy =
+  let doc = "For TLS, allow all protocol versions instead of just TLSv1.2" in
+  Arg.(value & flag & info ["ssl-legacy"] ~doc)
+
+let good_ciphersuites =
+  let doc = "The list of ciphersuites to allow for TLS" in
+  Arg.(value & opt (some string) None & info ["good-ciphersuites"] ~doc)
+
+let legacy_ciphersuites =
+  let doc = "Additional TLS ciphersuites allowed only if ssl-legacy is set" in
+  Arg.(value & opt (some string) None & info ["legacy-ciphersuites"] ~doc)
+
 let serve_cmd =
   let doc = "serve the contents of a disk" in
   let man = [
@@ -231,7 +243,7 @@ let stream_cmd =
     let doc = "Transport protocol for the destination data." in
     Arg.(value & opt (some string) None & info [ "destination-protocol" ] ~doc) in
   let stream_args_t =
-    Term.(pure StreamCommon.make $ source $ relative_to $ source_format $ destination_format $ destination $ destination_fd $ source_protocol $ destination_protocol $ prezeroed $ progress $ machine $ tar_filename_prefix) in
+    Term.(pure StreamCommon.make $ source $ relative_to $ source_format $ destination_format $ destination $ destination_fd $ source_protocol $ destination_protocol $ prezeroed $ progress $ machine $ tar_filename_prefix $ ssl_legacy $ good_ciphersuites $ legacy_ciphersuites) in
   Term.(ret(pure Impl.stream $ common_options_t $ stream_args_t)),
   Term.info "stream" ~sdocs:_common_options ~doc ~man
 

--- a/src/streamCommon.ml
+++ b/src/streamCommon.ml
@@ -41,9 +41,12 @@ type t = {
   progress: bool;
   machine: bool;
   tar_filename_prefix: string option;
+  ssl_legacy: bool;
+  good_ciphersuites: string option;
+  legacy_ciphersuites: string option;
 }
 
-let make source relative_to source_format destination_format destination destination_fd source_protocol destination_protocol prezeroed progress machine tar_filename_prefix =
+let make source relative_to source_format destination_format destination destination_fd source_protocol destination_protocol prezeroed progress machine tar_filename_prefix ssl_legacy good_ciphersuites legacy_ciphersuites =
   let source_protocol = protocol_of_string (require "source-protocol" source_protocol) in
   let destination_protocol = match destination_protocol with
     | None -> None
@@ -56,5 +59,5 @@ let make source relative_to source_format destination_format destination destina
     | None -> destination
     | Some fd -> "fd://" ^ (string_of_int fd) in
 
-  { source; relative_to; source_format; destination_format; destination; source_protocol; destination_protocol; prezeroed; progress; machine; tar_filename_prefix }
+  { source; relative_to; source_format; destination_format; destination; source_protocol; destination_protocol; prezeroed; progress; machine; tar_filename_prefix; ssl_legacy; good_ciphersuites; legacy_ciphersuites }
 


### PR DESCRIPTION
To enable TLSv1.2 capability for vhd-tool/sparse_dd,
This changes add 3 new options to CLI parameters,

ssl_legacy: boolean, allow all protocol versions instead of default TLSv1.2
good_ciphersuites: string, SSL good cipher suites for TLS protocols
legacy_ciphersuites: optional string, SSL legacy cipher suites for TLS protocols

Signed-off-by: Phus Lu <phus.lu@citrix.com>