### PR TITLE
CP-20761 Remove use of camlp4 lwt syntax extension

### DIFF
--- a/_oasis
+++ b/_oasis
@@ -16,7 +16,7 @@ Executable "vhd-tool"
   MainIs:             main.ml
   Custom:             true
   Install:            false
-  BuildDepends:       lwt, lwt.unix, lwt.syntax, lwt.preemptive, threads, vhd-format, vhd-format.lwt, cmdliner, nbd, nbd.lwt, uri, cohttp (>= 0.12.0), cohttp.lwt, tar, sha, sha.sha1, io-page.unix, threads, tapctl, re.str
+  BuildDepends:       lwt, lwt.unix, lwt.preemptive, threads, vhd-format, vhd-format.lwt, cmdliner, nbd, nbd.lwt, uri, cohttp (>= 0.12.0), cohttp.lwt, tar, sha, sha.sha1, io-page.unix, threads, tapctl, re.str
   CSources:           sendfile64_stubs.c
 
 Executable "sparse_dd"
@@ -26,7 +26,7 @@ Executable "sparse_dd"
   MainIs:             sparse_dd.ml
   Custom:             true
   Install:            false
-  BuildDepends:       lwt, lwt.unix, lwt.syntax, lwt.preemptive, threads, vhd-format, vhd-format.lwt, cmdliner, nbd, nbd.lwt, uri, cohttp (>= 0.12.0), cohttp.lwt, xenstore, xenstore.client, xenstore.unix, xenstore_transport, xenstore_transport.unix, threads, tapctl, xcp, sha, sha.sha1, tar, io-page.unix, re.str
+  BuildDepends:       lwt, lwt.unix, lwt.preemptive, threads, vhd-format, vhd-format.lwt, cmdliner, nbd, nbd.lwt, uri, cohttp (>= 0.12.0), cohttp.lwt, xenstore, xenstore.client, xenstore.unix, xenstore_transport, xenstore_transport.unix, threads, tapctl, xcp, sha, sha.sha1, tar, io-page.unix, re.str
   CSources:           sendfile64_stubs.c
 
 Executable get_vhd_vsize

--- a/_tags
+++ b/_tags
@@ -1,4 +1,3 @@
 # OASIS_START
 # OASIS_STOP
 <src/chunked.ml>: syntax_camlp4o, pkg_cstruct.syntax
-<src/input.ml>: syntax_camlp4o, pkg_lwt.syntax

--- a/src/impl.ml
+++ b/src/impl.ml
@@ -604,13 +604,13 @@ let retry common retries f =
   let rec aux n =
     if n <= 0 then f ()
     else
-      try_lwt f ()
-      with exn ->
-        if common.Common.debug then
-          Printf.fprintf stderr "warning: caught %s; will retry %d more time%s...\n%!"
-            (Printexc.to_string exn) n (if n=1 then "" else "s");
-        Lwt_unix.sleep 1. >>= fun () ->
-        aux (n - 1) in
+      Lwt.catch f
+        (fun exn ->
+           if common.Common.debug then
+             Printf.fprintf stderr "warning: caught %s; will retry %d more time%s...\n%!"
+               (Printexc.to_string exn) n (if n=1 then "" else "s");
+           Lwt_unix.sleep 1. >>= fun () ->
+           aux (n - 1)) in
   aux retries
 
 let make_stream common source relative_to source_format destination_format =

--- a/src/input.ml
+++ b/src/input.ml
@@ -30,7 +30,7 @@ let of_fd fd =
   { fd; offset }
 
 let read fd buf =
-  lwt () = IO.complete "read" (Some fd.offset) Lwt_bytes.read fd.fd buf in
+  IO.complete "read" (Some fd.offset) Lwt_bytes.read fd.fd buf >>= fun () ->
   fd.offset <- Int64.(add fd.offset (of_int (Cstruct.len buf)));
   return ()
 
@@ -42,7 +42,7 @@ let skip_to fd n =
     else
       let this = Int64.(to_int (min remaining (of_int (Cstruct.len buf)))) in
       let frag = Cstruct.sub buf 0 this in
-      lwt () = IO.complete "read" (Some fd.offset) Lwt_bytes.read fd.fd frag in
+      IO.complete "read" (Some fd.offset) Lwt_bytes.read fd.fd frag >>= fun () ->
       fd.offset <- Int64.(add fd.offset (of_int this));
       loop Int64.(sub remaining (of_int this)) in  
   loop Int64.(sub n fd.offset)


### PR DESCRIPTION
_This PR gets those [ppx changes](https://github.com/xapi-project/vhd-tool/tree/ppx-ely), which can be ported to trunk, into `master`. I could not port the `cstruct` changes into master, because it seems that the `cstruct` `1.4.0` version that we use there only has a camlp4 syntax extension._ 

We are moving away from camlp4 to ppx.

I did not update the files generated by OASIS, because this is done by
the Makefile anyway.

Signed-off-by: Gabor Igloi <gabor.igloi@citrix.com>