### PR TITLE
CP-20761: Rebase ppx-ely branch on trunk

### DIFF
--- a/_oasis
+++ b/_oasis
@@ -16,7 +16,7 @@ Executable "vhd-tool"
   MainIs:             main.ml
   Custom:             true
   Install:            false
-  BuildDepends:       lwt, lwt.unix, lwt.preemptive, threads, vhd-format, vhd-format.lwt, cmdliner, nbd, nbd.lwt, uri, cohttp (>= 0.12.0), cohttp.lwt, tar, sha, sha.sha1, io-page.unix, threads, tapctl, re.str
+  BuildDepends:       lwt, lwt.unix, lwt.preemptive, threads, vhd-format, vhd-format.lwt, cmdliner, nbd, nbd.lwt, uri, cohttp (>= 0.12.0), cohttp.lwt, tar, sha, sha.sha1, io-page.unix, threads, tapctl, re.str, cstruct.ppx
   CSources:           sendfile64_stubs.c
 
 Executable "sparse_dd"
@@ -26,7 +26,7 @@ Executable "sparse_dd"
   MainIs:             sparse_dd.ml
   Custom:             true
   Install:            false
-  BuildDepends:       lwt, lwt.unix, lwt.preemptive, threads, vhd-format, vhd-format.lwt, cmdliner, nbd, nbd.lwt, uri, cohttp (>= 0.12.0), cohttp.lwt, xenstore, xenstore.client, xenstore.unix, xenstore_transport, xenstore_transport.unix, threads, tapctl, xcp, sha, sha.sha1, tar, io-page.unix, re.str
+  BuildDepends:       lwt, lwt.unix, lwt.preemptive, threads, vhd-format, vhd-format.lwt, cmdliner, nbd, nbd.lwt, uri, cohttp (>= 0.12.0), cohttp.lwt, xenstore, xenstore.client, xenstore.unix, xenstore_transport, xenstore_transport.unix, threads, tapctl, xcp, sha, sha.sha1, tar, io-page.unix, re.str, cstruct.ppx
   CSources:           sendfile64_stubs.c
 
 Executable get_vhd_vsize

--- a/_tags
+++ b/_tags
@@ -1,3 +1,0 @@
-# OASIS_START
-# OASIS_STOP
-<src/chunked.ml>: syntax_camlp4o, pkg_cstruct.syntax

--- a/src/chunked.ml
+++ b/src/chunked.ml
@@ -12,11 +12,12 @@
  * GNU Lesser General Public License for more details.
  *)
 
-cstruct t {
-  uint64_t offset;
-  uint32_t len
+[%%cstruct
+type t = {
+  offset: uint64_t;
+  len: uint32_t;
   (* data *)
-} as little_endian
+} [@@little_endian]]
 
 let sizeof = sizeof_t
 

--- a/src/impl.ml
+++ b/src/impl.ml
@@ -215,7 +215,7 @@ let stream_nbd common c s prezeroed _ ?(progress = no_progress_bar) () =
   fold_left (fun (sector, work_done) x ->
     ( match x with
       | `Sectors data ->
-        Client.write server sector [data] >>= begin
+        Client.write server (Int64.mul sector 512L) [data] >>= begin
           function
           | `Ok () -> return Int64.(of_int (Cstruct.len data))
           | `Error e -> fail (Failure "Got error from NBD library")

--- a/src/impl.ml
+++ b/src/impl.ml
@@ -200,22 +200,26 @@ let stream_human common _ s _ _ ?(progress = no_progress_bar) () =
   return None
 
 let stream_nbd common c s prezeroed _ ?(progress = no_progress_bar) () =
-  let c = { Nbd_lwt_client.read = c.Channels.really_read; write = c.Channels.really_write } in
+  let open Nbd_lwt_unix in
+  let c = { Nbd.Channel.read = c.Channels.really_read; write = c.Channels.really_write; close = c.Channels.close } in
 
-  Nbd_lwt_client.negotiate c >>= fun (server, size, flags) ->
+  Client.negotiate c "" >>= fun (server, size, flags) ->
   (* Work to do is: non-zero data to write + empty sectors if the
      target is not prezeroed *)
   let total_work = let open Vhd.F in Int64.(add (add s.size.metadata s.size.copy) (if prezeroed then 0L else s.size.empty)) in
   let p = progress total_work in
 
   ( if not prezeroed then expand_empty s else return s ) >>= fun s ->
-  expand_copy s >>= fun s ->
+    expand_copy s >>= fun s ->
 
   fold_left (fun (sector, work_done) x ->
     ( match x with
       | `Sectors data ->
-        Nbd_lwt_client.write server data (Int64.mul sector 512L) >>= fun () ->
-        return Int64.(of_int (Cstruct.len data))
+        Client.write server sector [data] >>= begin
+          function
+          | `Ok () -> return Int64.(of_int (Cstruct.len data))
+          | `Error e -> fail (Failure "Got error from NBD library")
+        end
       | `Empty n -> (* must be prezeroed *)
         assert prezeroed;
         return 0L
@@ -481,7 +485,6 @@ let serve_vhd_to_raw total_size c dest prezeroed progress _ _ =
   loop 0 (-1L) 0L stream
 
 let serve_tar_to_raw total_size c dest prezeroed progress expected_prefix ignore_checksums =
-  let module M = Tar.Archive(Lwt) in
   let twomib = 2 * 1024 * 1024 in
   let buffer = IO.alloc twomib in
   let header = IO.alloc 512 in
@@ -803,9 +806,9 @@ let stream common args =
 
 let serve_nbd_to_raw common size c dest _ _ _ _ =
   let flags = [] in
-  let open Nbd in
-  let buf = Cstruct.create Negotiate.sizeof in
-  Negotiate.marshal buf { Negotiate.size; flags };
+  let open Nbd.Protocol in
+  let buf = Cstruct.create (Negotiate.sizeof `V1) in
+  Negotiate.marshal buf (Negotiate.V1 { Negotiate.size; flags });
   c.Channels.really_write buf >>= fun () ->
 
   let twomib = 2 * 1024 * 1024 in
@@ -835,17 +838,17 @@ let serve_nbd_to_raw common size c dest _ _ _ _ =
           c.Channels.really_read subblock >>= fun () ->
           Vhd_lwt.IO.really_write dest offset subblock
         ) request >>= fun () ->
-        Reply.marshal rep { Reply.error = 0l; handle = request.Request.handle };
+        Reply.marshal rep { Reply.error = `Ok (); handle = request.Request.handle };
         c.Channels.really_write rep
       | Command.Read ->
-        Reply.marshal rep { Reply.error = 0l; handle = request.Request.handle };
+        Reply.marshal rep { Reply.error = `Ok (); handle = request.Request.handle };
         c.Channels.really_write rep >>= fun () ->
         inblocks (fun offset subblock ->
           Vhd_lwt.IO.really_read dest offset subblock >>= fun () ->
           c.Channels.really_write subblock
         ) request
       | _ ->
-        Reply.marshal rep { Reply.error = 1l; handle = request.Request.handle };
+        Reply.marshal rep { Reply.error = `Error `EPERM; handle = request.Request.handle };
         c.Channels.really_write rep
       end >>= fun () ->
       serve_requests () in


### PR DESCRIPTION
* Use the newer ppx version of the cstruct library
* Update to PPX-based NBD library

The other part of the `ppx-ely` branch was ported to `master` in this PR: https://github.com/xapi-project/vhd-tool/pull/35