### PR TITLE
Remove generated myocamlbuild.ml

### DIFF
--- a/myocamlbuild.ml
+++ b/myocamlbuild.ml
@@ -1,3 +1,0 @@
-(* OASIS_START *)
-(* OASIS_STOP *)
-Ocamlbuild_plugin.dispatch dispatch_default;;


### PR DESCRIPTION
Removed file with the command
  oasis setup-clean -replace-sections -remove
This command removes all files generated by OASIS that do not have any
customizations.

This leftover file is not needed, because we auto-generate the OASIS
build files in the Makefile by running "oasis setup".

Signed-off-by: Gabor Igloi <gabor.igloi@citrix.com>