### PR TITLE
configure.ml: fix generated install file

### DIFF
--- a/configure.ml
+++ b/configure.ml
@@ -66,6 +66,7 @@ let configure bindir libexecdir etcdir =
       "]";
       "man: [";    
       "  \"vhd-tool.1\" { \"vhd-tool.1\" }";
+      "]";
     ] in
   output_file "vhd-tool.install" lines
 


### PR DESCRIPTION
The closing "]" was missing after the previous commit.

Signed-off-by: Gabor Igloi <gabor.igloi@citrix.com>