### PR TITLE
[merge on Thursday] Temporarily add missing is_tls field to nbd channel record

### DIFF
--- a/src/impl.ml
+++ b/src/impl.ml
@@ -201,7 +201,7 @@ let stream_human common _ s _ _ ?(progress = no_progress_bar) () =
 
 let stream_nbd common c s prezeroed _ ?(progress = no_progress_bar) () =
   let open Nbd_lwt_unix in
-  let c = { Nbd.Channel.read = c.Channels.really_read; write = c.Channels.really_write; close = c.Channels.close } in
+  let c = { Nbd.Channel.read = c.Channels.really_read; write = c.Channels.really_write; close = c.Channels.close; is_tls = false } in
 
   Client.negotiate c "" >>= fun (server, size, flags) ->
   (* Work to do is: non-zero data to write + empty sectors if the


### PR DESCRIPTION
We broke the clients of the nbd library when we introduced TLS. This is
a temporary change to fix the build. The new interface of the NBD
library still has to be finalized and polished.

Signed-off-by: Gabor Igloi <gabor.igloi@citrix.com>