### PR TITLE
CP-24605: Renamed library after porting to jbuilder.

### DIFF
--- a/src/jbuild
+++ b/src/jbuild
@@ -29,7 +29,7 @@ let () = Printf.ksprintf Jbuild_plugin.V1.send {|
     nbd.lwt
     re.str
     sha.sha1
-    tapctl
+    xapi-tapctl
     tar
     vhd-format
     vhd-format.lwt


### PR DESCRIPTION
This depends on https://github.com/xapi-project/netdev/pull/10