### PR TITLE
Remove redundant definition of (|>) pipe

### DIFF
--- a/cli/sparse_dd.ml
+++ b/cli/sparse_dd.ml
@@ -85,7 +85,6 @@ let startswith prefix x =
 	and x' = String.length x in
 	prefix' <= x' && (String.sub x 0 prefix' = prefix)
 
-let (|>) a b = b a
 module Opt = struct
 	let default d = function
 		| None -> d

--- a/src/image.ml
+++ b/src/image.ml
@@ -1,4 +1,3 @@
-let (|>) a b = b a
 module Opt = struct
 	let default d = function
 		| None -> d


### PR DESCRIPTION
`let (|>) a b = b a` has been a standard part of the language since OCaml 4.01. We can therefore remove these lines from our code.

Signed-off-by: Akanksha Mathur <akanksha.mathur@citrix.com>