### PR TITLE
sha.sha1 no longer exists since sha 1.12

### DIFF
--- a/src/jbuild
+++ b/src/jbuild
@@ -28,7 +28,7 @@ let () = Printf.ksprintf Jbuild_plugin.V1.send {|
     io-page.unix
     nbd-lwt-unix
     re.str
-    sha.sha1
+    sha
     xapi-tapctl
     tar
     vhd-format


### PR DESCRIPTION
Signed-off-by: Marcello Seri <marcello.seri@citrix.com>