### PR TITLE
CA-287921: Copy only allocated & non-zero extents in case of NBD device

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,19 @@
 language: c
-services: docker
+sudo: false
+services:
+  - docker
 install:
-    - wget https://raw.githubusercontent.com/xenserver/xenserver-build-env/master/utils/travis-build-repo.sh
-script:
-    - cp vhd-tool.opam opam && bash travis-build-repo.sh
-sudo: true
+  - wget https://raw.githubusercontent.com/ocaml/ocaml-ci-scripts/master/.travis-docker.sh
+script: bash -ex .travis-docker.sh
 env:
-    global:
-        - REPO_PACKAGE_NAME=vhd-tool
-        - REPO_CONFIGURE_CMD=""
-        - REPO_BUILD_CMD=make
-        - REPO_TEST_CMD=true
+  global:
+    - OCAML_VERSION=4.04.2
+    - DISTRO=centos-7
+    - PACKAGE=vhd-tool
+  matrix:
+    - BASE_REMOTE=git://github.com/xapi-project/xs-opam
+    - EXTRA_REMOTES=git://github.com/xapi-project/xs-opam
+matrix:
+  fast_finish: true
+  allow_failures:
+    - env: EXTRA_REMOTES=git://github.com/xapi-project/xs-opam

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,13 @@
-.PHONY: build release install uninstall clean reindent
+.PHONY: build release test install uninstall clean reindent
 
 build:
 	jbuilder build @install
 
 release:
 	jbuilder build @install
+
+test:
+	jbuilder runtest
 
 install:
 	jbuilder install

--- a/cli/sparse_dd.ml
+++ b/cli/sparse_dd.ml
@@ -352,20 +352,24 @@ let _ =
 		info "streaming from raw %s using BAT from %s (relative to %s) to raw %s" src vhd (string_opt relative_to) dest;
 		let t = Impl.make_stream common (src ^ ":" ^ vhd) relative_to "hybrid" "raw" in
 		t, dest, "raw"
-        | true, _, Some (`Vhd vhd), _, _, _ ->
+	| _, _, Some (`Nbd (server, export_name)), _, _, _ ->
+		let dest = rewrite_url dest in
+		let t = Impl.make_stream common (src ^ ":" ^ server ^ ":" ^ export_name) None "nbdhybrid" "raw" in
+		t, dest, "raw"
+	| true, _, Some (`Vhd vhd), _, _, _ ->
 		let dest = rewrite_url dest in
 		info "streaming from vhd %s (relative to %s) to raw %s" vhd (string_opt relative_to) dest;
-        	let t = Impl.make_stream common vhd relative_to "vhd" "raw" in
+		let t = Impl.make_stream common vhd relative_to "vhd" "raw" in
 		t, dest, "raw"
-        | _, _, Some (`Raw raw), _, _, _ ->
+	| _, _, Some (`Raw raw), _, _, _ ->
 		let dest = rewrite_url dest in
 		info "streaming from raw %s (relative to %s) to raw %s" raw (string_opt relative_to) dest;
-        	let t = Impl.make_stream common raw relative_to "raw" "raw" in
+		let t = Impl.make_stream common raw relative_to "raw" "raw" in
 		t, dest, "raw"
-        | _, device, None, _, _, _ ->
+	| _, device, None, _, _, _ ->
 		let dest = rewrite_url dest in
 		info "streaming from raw %s (relative to %s) to raw %s" src (string_opt relative_to) dest;
-        	let t = Impl.make_stream common device relative_to "raw" "raw" in
+		let t = Impl.make_stream common device relative_to "raw" "raw" in
 		t, dest, "raw" in
 
 	progress_cb 0.;

--- a/scripts/get_nbd_extents.py
+++ b/scripts/get_nbd_extents.py
@@ -1,0 +1,122 @@
+#!/usr/bin/python
+
+"""
+Returns a list of extents with their block statuses for an NBD export.
+
+This program uses new NBD capabilities introduced in QEMU 2.12.
+
+It uses the BLOCK_STATUS NBD extension, which is documented here:
+https://github.com/NetworkBlockDevice/nbd/blob/extension-blockstatus/doc/proto.md
+The structured replies functionality that this extension relies on is in the
+main branch of the NBD protocol docs:
+https://github.com/NetworkBlockDevice/nbd/blob/master/doc/proto.md
+"""
+
+import argparse
+import json
+import logging
+import logging.handlers
+
+from python_nbd_client import PythonNbdClient
+import python_nbd_client
+
+
+LOGGER = logging.getLogger("get_nbd_extents")
+LOGGER.setLevel(logging.DEBUG)
+# The log level of python_nbd_client is not set, therefore it will default to
+# that of the root logger, which is WARNING by default.
+
+# Request length is a 32-bit int.
+# It looks like for qemu 2.12, the length parameter of a NBD_CMD_BLOCK_STATUS
+# request is not limited by the maximum block size supported by the server (as
+# defined by NBD_INFO_BLOCK_SIZE), only by the size of a 32-bit int.
+MAX_REQUEST_LEN = 2 ** 32 - 1
+
+# Make the NBD_CMD_BLOCK_STATUS request aligned to 512 bytes, just in case. But
+# it looks like this is not required for qemu 2.12.
+MAX_REQUEST_LEN = MAX_REQUEST_LEN - (MAX_REQUEST_LEN % 512)
+
+def _get_extents(path, exportname):
+    with PythonNbdClient(
+        address=path, exportname=exportname, unix=True, use_tls=False, connect=False) as client:
+
+        client.negotiate_structured_reply()
+
+        # Select our metadata context. This context is documented at
+        # https://github.com/NetworkBlockDevice/nbd/blob/extension-blockstatus/doc/proto.md#baseallocation-metadata-context
+        context = 'base:allocation'
+        selected_contexts = client.set_meta_contexts(exportname, [context])
+        assert len(selected_contexts) == 1
+        (meta_context_id, meta_context_name) = selected_contexts[0]
+        assert meta_context_name == context
+
+        client.connect(exportname)
+
+        size = client.get_size()
+        LOGGER.debug(
+            'Connected to NBD export %s served at path %s of size %d bytes',
+            exportname, path, size)
+
+        offset = 0
+        while offset < size:
+            request_len = min(MAX_REQUEST_LEN, size - offset)
+            replies = client.query_block_status(offset, request_len)
+
+            # Process the returned structured reply chunks
+            # "For a successful return, the server MUST use a structured reply,
+            # containing exactly one chunk of type NBD_REPLY_TYPE_BLOCK_STATUS
+            # per selected context id"
+            assert len(replies) == 1
+            reply = replies[0]
+
+            # First make sure it's a block status reply
+            if python_nbd_client.is_error_chunk(reply_type=reply['reply_type']):
+                raise Exception('Received error: {}'.format(reply))
+            if reply['reply_type'] != python_nbd_client.NBD_REPLY_TYPE_BLOCK_STATUS:
+                raise Exception('Unexpected reply: {}'.format(reply))
+
+            # Then process the returned block status info
+            assert reply['context_id'] == meta_context_id
+            descriptors = reply['descriptors']
+            for descriptor in descriptors:
+                (length, flags) = descriptor
+                yield {'length':length, 'flags':flags}
+                offset += length
+                assert offset <= size
+
+
+def _main():
+    # Configure the root logger to log into syslog
+    # (Specifically, into /var/log/user.log)
+    syslog_handler = logging.handlers.SysLogHandler(
+        address='/dev/log',
+        facility=logging.handlers.SysLogHandler.LOG_USER)
+    # Ensure the program name is included in the log messages:
+    formatter = logging.Formatter('%(name)s: [%(levelname)s] %(message)s')
+    syslog_handler.setFormatter(formatter)
+    logging.getLogger().addHandler(syslog_handler)
+
+    try:
+        parser = argparse.ArgumentParser(
+            description="Return a list of extents with their block statuses")
+        parser.add_argument(
+            '--path',
+            required=True,
+            help="The path of the Unix domain socket of the NBD server")
+        parser.add_argument(
+            '--exportname',
+            required=True,
+            help="The export name of the device to connect to")
+
+        args = parser.parse_args()
+        LOGGER.debug('Called with args %s', args)
+
+        extents = list(_get_extents(path=args.path, exportname=args.exportname))
+        print json.dumps(extents)
+    except Exception as exc:
+        LOGGER.exception(exc)
+        raise
+
+
+if __name__ == '__main__':
+    _main()

--- a/scripts/python_nbd_client.py
+++ b/scripts/python_nbd_client.py
@@ -1,0 +1,675 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2013 Nodalink, SARL.
+#
+# Simple nbd client used to connect to qemu-nbd
+#
+# author: Benoît Canet <benoit.canet@irqsave.net>
+#
+# This work is open source software, licensed under the terms of the
+# BSD license as described in the LICENSE file in the top-level directory.
+#
+
+# Original file from
+# https://github.com/cloudius-systems/osv/blob/master/scripts/nbd_client.py ,
+# added support for (non-fixed) newstyle negotation,
+# then @thomasmck added support for fixed-newstyle negotiation and TLS
+
+"""
+A pure-Python NBD client.
+
+This client implement the NBD protocol, and supports both the oldstyle and
+newstyle negotiations:
+https://github.com/NetworkBlockDevice/nbd/blob/master/doc/proto.md
+Additionally, it supports the BLOCK_STATUS extension:
+https://github.com/NetworkBlockDevice/nbd/blob/extension-blockstatus/doc/proto.md
+"""
+
+import socket
+import struct
+import ssl
+import logging
+
+LOGGER = logging.getLogger('python_nbd_client')
+
+# Request types
+NBD_CMD_READ = 0
+NBD_CMD_WRITE = 1
+# a disconnect request
+NBD_CMD_DISC = 2
+NBD_CMD_FLUSH = 3
+NBD_CMD_BLOCK_STATUS = 7
+
+# Transmission flags
+NBD_FLAG_HAS_FLAGS = (1 << 0)
+NBD_FLAG_SEND_FLUSH = (1 << 2)
+
+# Client flags
+NBD_FLAG_C_FIXED_NEWSTYLE = (1 << 0)
+
+# Option types
+NBD_OPT_EXPORT_NAME = 1
+NBD_OPT_ABORT = 2
+NBD_OPT_STARTTLS = 5
+NBD_OPT_INFO = 6
+NBD_OPT_STRUCTURED_REPLY = 8
+NBD_OPT_LIST_META_CONTEXT = 9
+NBD_OPT_SET_META_CONTEXT = 10
+
+# Option reply types
+NBD_REP_ERROR_BIT = (1 << 31)
+NBD_REP_ACK = 1
+NBD_REP_INFO = 3
+NBD_REP_META_CONTEXT = 4
+
+OPTION_REPLY_MAGIC = 0x3e889045565a9
+
+NBD_REQUEST_MAGIC = 0x25609513
+NBD_SIMPLE_REPLY_MAGIC = 0x67446698
+NBD_STRUCTURED_REPLY_MAGIC = 0x668e33ef
+
+# Structured reply types
+NBD_REPLY_TYPE_NONE = 0
+NBD_REPLY_TYPE_OFFSET_DATA = 1
+NBD_REPLY_TYPE_OFFSET_HOLE = 2
+NBD_REPLY_TYPE_BLOCK_STATUS = 5
+NBD_REPLY_TYPE_ERROR_BIT = (1 << 15)
+NBD_REPLY_TYPE_ERROR = (1 << 15 + 1)
+NBD_REPLY_TYPE_ERROR_OFFSET = (1 << 15 + 2)
+
+# Structured reply flags
+NBD_REPLY_FLAG_DONE = (1 << 0)
+
+# NBD_INFO information types
+NBD_INFO_EXPORT = 0
+NBD_INFO_NAME = 1
+NBD_INFO_DESCRIPTION = 2
+NBD_INFO_BLOCK_SIZE = 3
+
+
+class NBDEOFError(EOFError):
+    """
+    An end of file error happened while reading from the socket, because it has
+    been closed.
+    """
+    pass
+
+
+class NBDTransmissionError(Exception):
+    """
+    The NBD server returned a non-zero error value in its response to a
+    request.
+
+    :attribute error_code: The error code returned by the server.
+    """
+    def __init__(self, error_code):
+        super(NBDTransmissionError, self).__init__(
+            "Server returned error during transmission: {}".format(error_code))
+        self.error_code = error_code
+
+
+class NBDOptionError(Exception):
+    """
+    The NBD server replied with an error to the option sent by the client.
+
+    :attribute reply: The error reply sent by the server.
+    """
+    def __init__(self, reply):
+        error_code = reply - NBD_REP_ERROR_BIT
+        super(NBDOptionError, self).__init__(
+            "Server returned error during option haggling: "
+            "reply type={}; error code={}".format(reply, error_code))
+        self.reply = reply
+
+
+class NBDUnexpectedOptionResponseError(Exception):
+    """
+    The NBD server sent a response to an option different from the most recent
+    one that the client is expecting a response to.
+
+    :attribute expected: The option that was last sent by the client, to which
+                         it is expecting a response.
+    :attribute received: The server's response is a reply to this option.
+    """
+    def __init__(self, expected, received):
+        super(NBDUnexpectedOptionResponseError, self).__init__(
+            "Received response to unexpected option {}; "
+            "was expecting a response to option {}"
+            .format(received, expected))
+        self.expected = expected
+        self.received = received
+
+
+class NBDUnexpectedStructuredReplyType(Exception):
+    """
+    The NBD server sent a structured reply chunk with an unexpected type that
+    is not known by this client.
+
+    :attribute type: The type of the structured chunk message.
+    """
+    def __init__(self, reply_type):
+        super(NBDUnexpectedStructuredReplyType, self).__init__(
+            "Received a structured reply chunk message "
+            "with an unexpected type: {}".format(reply_type))
+        self.reply_type = reply_type
+
+
+class NBDUnexpectedReplyHandleError(Exception):
+    """
+    The NBD server sent a reply to a request different from the most recent one
+    that the client is expecting a response to.
+
+    :attribute expected: The handle of the most recent request that the client
+                         is expecting a reply to.
+    :attribute received: The server's reply contained this handle.
+    """
+    def __init__(self, expected, received):
+        super(NBDUnexpectedReplyHandleError, self).__init__(
+            "Received reply with unexpected handle {}; "
+            "was expecting a response to the request with "
+            "handle {}"
+            .format(received, expected))
+        self.expected = expected
+        self.received = received
+
+
+class NBDProtocolError(Exception):
+    """
+    The NBD server sent an invalid response that is not allowed by the NBD
+    protocol.
+    """
+    pass
+
+
+def _assert_protocol(assertion):
+    if assertion is False:
+        raise NBDProtocolError
+
+
+def _check_alignment(name, value):
+    if not value % 512:
+        return
+    raise ValueError("%s=%i is not a multiple of 512" % (name, value))
+
+
+def _is_final_structured_reply_chunk(flags):
+    return flags & NBD_REPLY_FLAG_DONE == NBD_REPLY_FLAG_DONE
+
+
+def is_error_chunk(reply_type):
+    """
+    Returns true if the structured reply chunk with the given type is an error
+    chunk.
+    """
+    return reply_type & NBD_REPLY_TYPE_ERROR_BIT != 0
+
+
+class PythonNbdClient(object):
+    """
+    A pure-Python NBD client. Supports both the fixed-newstyle and the oldstyle
+    negotiation, and also has support for upgrading the connection to TLS
+    during fixed-newstyle negotiation, structured replies, and the BLOCK_STATUS
+    extension.
+    """
+
+    def __init__(self,
+                 address,
+                 exportname="",
+                 port=10809,
+                 timeout=60,
+                 subject=None,
+                 cert=None,
+                 use_tls=True,
+                 new_style_handshake=True,
+                 unix=False,
+                 connect=True):
+        LOGGER.info("Creating connection to address '%s' and port '%s'", address, port)
+        self._flushed = True
+        self._closed = True
+        self._handle = 0
+        self._last_sent_option = None
+        self._structured_reply = False
+        self._transmission_phase = False
+        if unix:
+            self._s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        else:
+            self._s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        if not unix:
+            address = (address, int(port))
+        self._s.settimeout(timeout)
+        self._s.connect(address)
+        self._closed = False
+        if new_style_handshake:
+            self._fixed_new_style_handshake(
+                cert=cert,
+                subject=subject,
+                use_tls=use_tls)
+            if connect:
+                self.connect(exportname=exportname)
+        else:
+            self._old_style_handshake()
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        self.close()
+
+    def close(self):
+        """
+        Sends a flush request to the server if necessary and the server
+        supports it, followed by a disconnect request.
+        """
+        if self._transmission_phase and (not self._flushed):
+            self.flush()
+        if not self._closed:
+            self._disconnect()
+            self._closed = True
+
+    def _recvall(self, length):
+        data = bytearray(length)
+        view = memoryview(data)
+        bytes_left = length
+        while bytes_left:
+            received = self._s.recv_into(view, bytes_left)
+            # If recv reads 0 bytes, that means the peer has properly
+            # shut down the TCP session (end-of-file error):
+            if not received:
+                raise NBDEOFError
+            view = view[received:]
+            bytes_left -= received
+        return data
+
+    # Handshake phase
+
+    #  Newstyle handshake
+
+    def _send_option(self, option, data=b''):
+        LOGGER.debug("NBD sending option header")
+        data_length = len(data)
+        LOGGER.debug("option='%d' data_length='%d'", option, data_length)
+        self._s.sendall(b'IHAVEOPT')
+        header = struct.pack(">LL", option, data_length)
+        self._s.sendall(header + data)
+        self._last_sent_option = option
+
+    def _parse_option_reply(self):
+        LOGGER.debug("NBD parsing option reply")
+        reply = self._recvall(8 + 4 + 4 + 4)
+        (magic, option, reply_type, data_length) = struct.unpack(
+            ">QLLL", reply)
+        LOGGER.debug("NBD reply magic='0x%x' option='%d' reply_type='%d'",
+                     magic, option, reply_type)
+        _assert_protocol(magic == OPTION_REPLY_MAGIC)
+        if option != self._last_sent_option:
+            raise NBDUnexpectedOptionResponseError(
+                expected=self._last_sent_option, received=option)
+        if reply_type & NBD_REP_ERROR_BIT != 0:
+            raise NBDOptionError(reply=reply_type)
+        data = self._recvall(data_length)
+        return (reply_type, data)
+
+    def _parse_option_reply_ack(self):
+        (reply_type, data) = self._parse_option_reply()
+        if reply_type != NBD_REP_ACK:
+            raise NBDProtocolError()
+        return data
+
+    def _parse_meta_context_reply(self):
+        (reply_type, data) = self._parse_option_reply()
+        if reply_type == NBD_REP_ACK:
+            return None
+        _assert_protocol(reply_type == NBD_REP_META_CONTEXT)
+        context_id = struct.unpack(">L", data[:4])[0]
+        name = (data[4:]).decode('utf-8')
+        return (context_id, name)
+
+    def _upgrade_socket_to_tls(self, cert, subject):
+        # Forcing the client to use TLSv1_2
+        context = ssl.SSLContext(ssl.PROTOCOL_TLSv1_2)
+        context.options &= ~ssl.OP_NO_TLSv1
+        context.options &= ~ssl.OP_NO_TLSv1_1
+        context.options &= ~ssl.OP_NO_SSLv2
+        context.options &= ~ssl.OP_NO_SSLv3
+        context.verify_mode = ssl.CERT_REQUIRED
+        context.check_hostname = (subject is not None)
+        context.load_verify_locations(cadata=cert)
+        cleartext_socket = self._s
+        self._s = context.wrap_socket(
+            cleartext_socket,
+            server_side=False,
+            do_handshake_on_connect=True,
+            server_hostname=subject)
+
+    def _initiate_tls_upgrade(self):
+        # start TLS negotiation
+        self._send_option(NBD_OPT_STARTTLS)
+        # receive reply
+        data = self._parse_option_reply_ack()
+        _assert_protocol(len(data) == 0)
+
+    def request_info(self, export_name, info_requests):
+        """Query information from the server."""
+        data = struct.pack('>L', len(export_name))
+        data += export_name.encode('utf-8')
+        data += struct.pack('>H', len(info_requests))
+        for request in info_requests:
+            data += struct.pack('>H', request)
+        self._send_option(NBD_OPT_INFO, data)
+        infos = []
+        while True:
+            (reply_type, data) = self._parse_option_reply()
+            if reply_type == NBD_REP_INFO:
+                info_type = struct.unpack(">H", data[:2])[0]
+                info = {'information_type': info_type}
+                payload = data[2:]
+                if info_type == NBD_INFO_BLOCK_SIZE:
+                    _assert_protocol(len(data) == 14)
+                    (info['minimum_block_size'],
+                     info['preferred_block_size'],
+                     info['maximum_block_size']) = struct.unpack('>LLL', payload)
+                    infos += [info]
+                elif info_type == NBD_INFO_EXPORT:
+                    _assert_protocol(len(data) == 12)
+                    (info['size'],
+                     info['transmission_flags']) = struct.unpack('>QH', payload)
+                    infos += [info]
+                else:
+                    # The client MUST ignore information replies it does not
+                    # understand.
+                    LOGGER.warning('Unsupported info reply type: %d', info_type)
+            elif reply_type == NBD_REP_ACK:
+                _assert_protocol(not data)
+                break
+            else:
+                raise NBDProtocolError(
+                    'Unexpected reply type: {}'.format(reply_type))
+        return infos
+
+    def negotiate_structured_reply(self):
+        """
+        Negotiate use of the structured reply extension, fail if unsupported.
+        Only valid during the handshake phase.
+        """
+        self._send_option(NBD_OPT_STRUCTURED_REPLY)
+        self._parse_option_reply_ack()
+        self._structured_reply = True
+
+    def _process_meta_context_option(self, option, export_name, queries):
+        data = struct.pack('>L', len(export_name))
+        data += export_name.encode('utf-8')
+        data += struct.pack('>L', len(queries))
+        for query in queries:
+            data += struct.pack('>L', len(query))
+            data += query.encode('utf-8')
+        self._send_option(option, data)
+        while True:
+            reply = self._parse_meta_context_reply()
+            if reply is None:
+                break
+            yield reply
+
+    def _send_meta_context_option(self, option, export_name, queries):
+        return list(self._process_meta_context_option(option, export_name, queries))
+
+    def set_meta_contexts(self, export_name, queries):
+        """
+        Change the set of active metadata contexts. Only valid during the
+        handshake phase. Returns the list of selected metadata contexts as
+        (metadata context ID, metadata context name) pairs.
+        Structured replies must be negotiated first using
+        negotiate_structured_reply.
+        """
+        return self._send_meta_context_option(
+            option=NBD_OPT_SET_META_CONTEXT,
+            export_name=export_name,
+            queries=queries)
+
+    def list_meta_contexts(self, export_name, queries):
+        """
+        Return the metadata contexts available on the export matching one or
+        more of the queries as (metadata context ID, metadata context name)
+        pairs.
+        Structured replies be negotiated first using
+        negotiate_structured_reply.
+        """
+        return self._send_meta_context_option(
+            option=NBD_OPT_LIST_META_CONTEXT,
+            export_name=export_name,
+            queries=queries)
+
+    def _fixed_new_style_handshake(self, cert, subject, use_tls):
+        nbd_magic = self._recvall(len("NBDMAGIC"))
+        _assert_protocol(nbd_magic == b'NBDMAGIC')
+        nbd_magic = self._recvall(len("IHAVEOPT"))
+        _assert_protocol(nbd_magic == b'IHAVEOPT')
+        buf = self._recvall(2)
+        handshake_flags = struct.unpack(">H", buf)[0]
+        _assert_protocol(handshake_flags & NBD_FLAG_HAS_FLAGS != 0)
+        client_flags = NBD_FLAG_C_FIXED_NEWSTYLE
+        client_flags = struct.pack('>L', client_flags)
+        self._s.sendall(client_flags)
+
+        if use_tls:
+            # start TLS negotiation
+            self._initiate_tls_upgrade()
+            # upgrade socket to TLS
+            self._upgrade_socket_to_tls(cert, subject)
+
+    def connect(self, exportname):
+        """
+        Valid only during the handshake phase. Requests the given
+        export and enters the transmission phase.
+        """
+        LOGGER.info("Connecting to export '%s' using newstyle negotiation", exportname)
+        # request export
+        self._send_option(NBD_OPT_EXPORT_NAME, str.encode(exportname))
+
+        # non-fixed newstyle negotiation: we get these if the server is willing
+        # to allow the export
+        buf = self._recvall(10)
+        (self._size, self._transmission_flags) = struct.unpack(">QH", buf)
+        LOGGER.debug("NBD got size=%d transmission flags=%d", self._size, self._transmission_flags)
+        # ignore the zeroes
+        zeroes = self._recvall(124)
+        LOGGER.debug("NBD got zeroes: %s", zeroes)
+        self._transmission_phase = True
+        LOGGER.debug("Connected")
+
+    #  Oldstyle handshake
+
+    def _old_style_handshake(self):
+        LOGGER.info("Connecting to server using oldstyle negotiation")
+        nbd_magic = self._recvall(len("NBDMAGIC"))
+        _assert_protocol(nbd_magic == b'NBDMAGIC')
+        buf = self._recvall(8 + 8 + 4)
+        (magic, self._size, self._transmission_flags) = struct.unpack(">QQL", buf)
+        _assert_protocol(magic == 0x00420281861253)
+        # ignore trailing zeroes
+        self._recvall(124)
+        self._transmission_phase = True
+
+    # Transmission phase
+
+    def _send_request_header(self, request_type, offset, length):
+        LOGGER.debug("NBD request offset=%d length=%d", offset, length)
+        command_flags = 0
+        self._handle += 1
+        header = struct.pack('>LHHQQL', NBD_REQUEST_MAGIC, command_flags,
+                             request_type, self._handle, offset, length)
+        self._s.sendall(header)
+
+    def _check_handle(self, handle):
+        if handle != self._handle:
+            raise NBDUnexpectedReplyHandleError(
+                expected=self._handle, received=handle)
+
+    def _parse_simple_reply(self, data_length=0):
+        LOGGER.debug("NBD parsing simple reply, data_length=%d", data_length)
+        reply = self._recvall(4 + 4 + 8)
+        (magic, errno, handle) = struct.unpack(">LLQ", reply)
+        LOGGER.debug("NBD simple reply magic='0x%x' errno='%d' handle='%d'",
+                     magic, errno, handle)
+        _assert_protocol(magic == NBD_SIMPLE_REPLY_MAGIC)
+        self._check_handle(handle)
+        data = self._recvall(length=data_length)
+        LOGGER.debug("NBD response received data_length=%d bytes", data_length)
+        if errno != 0:
+            raise NBDTransmissionError(errno)
+        return data
+
+    def _handle_block_status_reply(self, fields):
+        data_length = fields['data_length']
+        _assert_protocol((data_length >= 12) and (data_length % 8 == 4))
+        data = self._recvall(data_length)
+        view = memoryview(data)
+        fields['context_id'] = struct.unpack(">L", view[:4])[0]
+        view = view[4:]
+        descriptors = []
+        while view:
+            (length, status_flags) = struct.unpack(">LL", view[:8])
+            descriptors += [(length, status_flags)]
+            view = view[8:]
+        _assert_protocol(descriptors)
+        fields['descriptors'] = descriptors
+
+    def _handle_data_reply(self, fields):
+        data_length = fields['data_length']
+        _assert_protocol(data_length >= 9)
+        buf = self._recvall(8)
+        fields['offset'] = struct.unpack(">Q", buf)[0]
+        fields['data'] = self._recvall(data_length - 8)
+        _assert_protocol(fields['data'])
+
+    def _handle_hole_reply(self, fields):
+        _assert_protocol(fields['data_length'] == 12)
+        buf = self._recvall(12)
+        (fields['offset'], fields['hole_size']) = struct.unpack(">QL", buf)
+
+    def _handle_structured_reply_error(self, fields):
+        data_length = fields['data_length']
+        _assert_protocol(data_length >= 6)
+        buf = self._recvall(4 + 2)
+        (errno, message_length) = struct.unpack(">LH", buf)
+        fields['error'] = errno
+        remaining_length = data_length - 6
+        # The client MAY continue transmission in case of an unexpected error
+        # type, unless message_length does not fit into the length:
+        if message_length > remaining_length:
+            raise NBDProtocolError(
+                'message_length is too large to fit within data_length bytes')
+        data = self._recvall(remaining_length)
+        view = memoryview(data)
+        fields['message'] = view[0:message_length].tobytes().decode('utf-8')
+        view = view[message_length:]
+        if fields['reply_type'] == NBD_REPLY_TYPE_ERROR_OFFSET:
+            fields['offset'] = struct.unpack(">Q", view)[0]
+
+    def _parse_structured_reply_chunk(self):
+        LOGGER.debug("NBD parsing structured reply chunk")
+        reply = self._recvall(4 + 2 + 2 + 8 + 4)
+        (magic, flags, reply_type, handle, data_length) = struct.unpack(">LHHQL", reply)
+        LOGGER.debug("NBD structured reply magic='%x' flags='%s' "
+                     "reply_type='%d' handle='%d' data_length='%d'",
+                     magic, flags, reply_type, handle, data_length)
+        _assert_protocol(magic == NBD_STRUCTURED_REPLY_MAGIC)
+        self._check_handle(handle)
+        fields = {'flags': flags, 'reply_type': reply_type, 'data_length': data_length}
+        if reply_type == NBD_REPLY_TYPE_BLOCK_STATUS:
+            self._handle_block_status_reply(fields)
+        elif reply_type == NBD_REPLY_TYPE_NONE:
+            _assert_protocol(data_length == 0)
+            _assert_protocol(_is_final_structured_reply_chunk(flags=flags))
+        elif reply_type == NBD_REPLY_TYPE_OFFSET_DATA:
+            self._handle_data_reply(fields)
+        elif reply_type == NBD_REPLY_TYPE_OFFSET_HOLE:
+            self._handle_hole_reply(fields)
+        elif is_error_chunk(reply_type=reply_type):
+            self._handle_structured_reply_error(fields)
+        else:
+            raise NBDUnexpectedStructuredReplyType(reply_type)
+        return fields
+
+    def _parse_structured_reply_chunks(self):
+        while True:
+            reply = self._parse_structured_reply_chunk()
+            yield reply
+            if _is_final_structured_reply_chunk(flags=reply['flags']):
+                return
+
+    def write(self, data, offset):
+        """
+        Writes the given bytes to the export, starting at the given
+        offset.
+        """
+        LOGGER.debug("NBD_CMD_WRITE")
+        _check_alignment("offset", offset)
+        _check_alignment("size", len(data))
+        self._flushed = False
+        self._send_request_header(NBD_CMD_WRITE, offset, len(data))
+        self._s.sendall(data)
+        # TODO: the server MAY respond with a structured reply (e.g. to report errors)
+        self._parse_simple_reply()
+        return len(data)
+
+    def read(self, offset, length):
+        """
+        Returns length number of bytes read from the export, starting at
+        the given offset.
+        If structured replies have been negotiated, it returns a generator
+        containing the reply chunks. The caller must consume this generator
+        before further NBD commands, since this client does not support
+        asynchronous request processing.
+        """
+        LOGGER.debug("NBD_CMD_READ")
+        _check_alignment("offset", offset)
+        _check_alignment("length", length)
+        self._send_request_header(NBD_CMD_READ, offset, length)
+        if self._structured_reply:
+            return self._parse_structured_reply_chunks()
+        data = self._parse_simple_reply(length)
+        return data
+
+    def _need_flush(self):
+        return self._transmission_flags & NBD_FLAG_SEND_FLUSH != 0
+
+    def flush(self):
+        """
+        Sends a flush request to the server if the server supports it
+        and there are unflushed writes. This causes all completed writes
+        (the writes for which the server has already sent a reply to the
+        client) to be written to permanent storage.
+        """
+        if self._need_flush() is False:
+            self._flushed = True
+            return True
+        LOGGER.debug("NBD_CMD_FLUSH")
+        self._send_request_header(NBD_CMD_FLUSH, 0, 0)
+        # TODO: the server MAY respond with a structured reply (e.g. to report errors)
+        self._parse_simple_reply()
+        self._flushed = True
+
+    def query_block_status(self, offset, length):
+        """
+        Query block status in the range defined by length and offset.
+        Returns a list of structured reply chunks.
+        The required meta contexts must have been negotiated using
+        set_meta_contexts.
+        """
+        LOGGER.debug("NBD_CMD_BLOCK_STATUS")
+        self._send_request_header(NBD_CMD_BLOCK_STATUS, offset, length)
+        return list(self._parse_structured_reply_chunks())
+
+    def _disconnect(self):
+        if self._transmission_phase:
+            LOGGER.debug("NBD_CMD_DISC")
+            self._send_request_header(NBD_CMD_DISC, 0, 0)
+        else:
+            self._send_option(NBD_OPT_ABORT)
+
+    def get_size(self):
+        """
+        Return the size of the device in bytes.
+        """
+        return self._size

--- a/src/image.ml
+++ b/src/image.ml
@@ -47,15 +47,13 @@ let get_nbd_device path =
   end else None
 
 let of_device path =
-  try
-    match Tapctl.of_device (Tapctl.create ()) path with
-    | _, _, (Some ("vhd", vhd)) -> Some (`Vhd vhd)
-    | _, _, (Some ("aio", vhd)) -> Some (`Raw vhd)
-    | _, _, _ -> raise Not_found
-  with
-  | Tapctl.Not_blktap ->
+  match Tapctl.of_device (Tapctl.create ()) path with
+  | _, _, (Some ("vhd", vhd)) -> Some (`Vhd vhd)
+  | _, _, (Some ("aio", vhd)) -> Some (`Raw vhd)
+  | _, _, _ -> None
+  | exception Tapctl.Not_blktap ->
     get_nbd_device path
-  | Tapctl.Not_a_device ->
+  | exception Tapctl.Not_a_device ->
     None
-  | _ ->
+  | exception _ ->
     None

--- a/src/image.ml
+++ b/src/image.ml
@@ -1,32 +1,61 @@
+let get_device_numbers path =
+  let rdev = (Unix.LargeFile.stat path).Unix.LargeFile.st_rdev in
+  let major = rdev / 256 and minor = rdev mod 256 in
+  (major, minor)
+
+let is_nbd_device path =
+  let nbd_device_num = 43 in
+  let (major, _) = get_device_numbers path in
+  major = nbd_device_num
+
 module Opt = struct
-	let default d = function
-		| None -> d
-		| Some x -> x
+  let default d = function
+    | None -> d
+    | Some x -> x
 end
 
-let startswith prefix x =
-	let prefix' = String.length prefix
-	and x' = String.length x in
-	prefix' <= x' && (String.sub x 0 prefix' = prefix)
-
 type t = [
-	| `Vhd of string
-	| `Raw of string
+  | `Vhd of string
+  | `Raw of string
+  | `Nbd of string * string
 ]
 
 let to_string = function
-	| `Vhd x -> "vhd:" ^ x
-	| `Raw x -> "raw:" ^ x
+  | `Vhd x -> "vhd:" ^ x
+  | `Raw x -> "raw:" ^ x
+  | `Nbd (x,y) -> Printf.sprintf "nbd:(%s,%s)" x y
+
+type nbd_connect_info =
+  { path : string
+  ; exportname : string
+  } [@@deriving rpc]
+
+let get_nbd_device path =
+  let nbd_device_prefix = "/dev/nbd" in
+  if Astring.String.is_prefix ~affix:nbd_device_prefix path && is_nbd_device path then begin
+    let nbd_number =
+      String.sub path (String.length nbd_device_prefix) (String.length path - String.length nbd_device_prefix)
+    in
+    let { path; exportname } =
+      let persistent_nbd_info_dir = "/var/run/nonpersistent/nbd" in
+      let filename = persistent_nbd_info_dir ^ "/" ^ nbd_number in
+      Xapi_stdext_unix.Unixext.string_of_file filename
+      |> Jsonrpc.of_string
+      |> nbd_connect_info_of_rpc
+    in
+    Some (`Nbd (path, exportname))
+  end else None
 
 let of_device path =
-	try 
-		match Tapctl.of_device (Tapctl.create ()) path with
-		| _, _, (Some ("vhd", vhd)) -> Some (`Vhd vhd)
-		| _, _, (Some ("aio", vhd)) -> Some (`Raw vhd)
-		| _, _, _ -> raise Not_found
-	with Tapctl.Not_blktap ->
-		None
-	| Tapctl.Not_a_device ->
-		None
-	| _ -> 
-		None
+  try
+    match Tapctl.of_device (Tapctl.create ()) path with
+    | _, _, (Some ("vhd", vhd)) -> Some (`Vhd vhd)
+    | _, _, (Some ("aio", vhd)) -> Some (`Raw vhd)
+    | _, _, _ -> raise Not_found
+  with
+  | Tapctl.Not_blktap ->
+    get_nbd_device path
+  | Tapctl.Not_a_device ->
+    None
+  | _ ->
+    None

--- a/src/image.mli
+++ b/src/image.mli
@@ -1,8 +1,8 @@
 
 type t = [
-	| `Vhd of string
-    | `Raw of string
-    | `Nbd of (string * string)
+  | `Vhd of string
+  | `Raw of string
+  | `Nbd of (string * string)
 ]
 (** An image may either be backed by a vhd-format file or a
     raw-format file. *)

--- a/src/image.mli
+++ b/src/image.mli
@@ -1,7 +1,8 @@
 
 type t = [
 	| `Vhd of string
-	| `Raw of string
+    | `Raw of string
+    | `Nbd of (string * string)
 ]
 (** An image may either be backed by a vhd-format file or a
     raw-format file. *)

--- a/src/impl.ml
+++ b/src/impl.ml
@@ -626,6 +626,15 @@ let retry common retries f =
 
 let make_stream common source relative_to source_format destination_format =
   match source_format, destination_format with
+  | "nbdhybrid", "raw" ->
+    begin match Re_str.bounded_split colon source 3 with
+    | [ raw; nbd_server; export_name ] -> begin
+      Vhd_format_lwt.IO.openfile raw false >>= fun raw ->
+      Nbd_input.raw raw nbd_server export_name
+      end
+    | _ ->
+      fail (Failure (Printf.sprintf "Failed to parse nbdhybrid source: %s (expecting <raw_disk>:<nbd_server>:<export_name>" source))
+    end
   | "hybrid", "raw" ->
     (* expect source to be block_device:vhd *)
     begin match Re_str.bounded_split colon source 2 with

--- a/src/jbuild
+++ b/src/jbuild
@@ -22,23 +22,23 @@ let () = Printf.ksprintf Jbuild_plugin.V1.send {|
   (c_names (sendfile64_stubs))
   (flags (:standard -w -34-32 %s))
   (libraries (
-    lwt
-    cstruct
     cohttp.lwt
+    cstruct
     io-page.unix
+    lwt
     nbd-lwt-unix
     re.str
+    rpclib
+    rpclib.json
     sha
-    xapi-tapctl
     tar
     vhd-format
     vhd-format-lwt
+    xapi-tapctl
     xenstore.client
     xenstore.unix
     xenstore_transport
     xenstore_transport.unix
-    rpclib
-    rpclib.json
   ))
 ))
 |} (flags ["cstruct.ppx"; "ppx_deriving_rpc"])

--- a/src/jbuild
+++ b/src/jbuild
@@ -37,6 +37,8 @@ let () = Printf.ksprintf Jbuild_plugin.V1.send {|
     xenstore.unix
     xenstore_transport
     xenstore_transport.unix
+    rpclib
+    rpclib.json
   ))
 ))
-|} (flags ["cstruct.ppx"])
+|} (flags ["cstruct.ppx"; "ppx_deriving_rpc"])

--- a/src/nbd_input.ml
+++ b/src/nbd_input.ml
@@ -13,13 +13,12 @@ let flag_hole = 1l
 let flag_zero = 2l
 type extent_list = extent list [@@deriving rpc]
 
-let get_extents_json ~server ~export_name =
-  let extent_reader = "/opt/xensource/libexec/get_nbd_extents.py" in
+let get_extents_json ~extent_reader ~server ~export_name =
   Lwt_process.pread
     ("", [|extent_reader; "--path"; server; "--exportname"; export_name|])
 
-let raw : Vhd_format_lwt.IO.fd -> string -> string -> Vhd_format_lwt.IO.fd F.stream Lwt.t = fun raw server export_name ->
-  get_extents_json ~server ~export_name >>= fun extents_json ->
+let raw ?(extent_reader="/opt/xensource/libexec/get_nbd_extents.py") raw server export_name =
+  get_extents_json ~extent_reader ~server ~export_name >>= fun extents_json ->
   let extents = extent_list_of_rpc (Jsonrpc.of_string extents_json) in
   let to_sectors b = Int64.div b 512L in
   let is_empty e =

--- a/src/nbd_input.ml
+++ b/src/nbd_input.ml
@@ -1,0 +1,57 @@
+module F = Vhd_format.F.From_file(Vhd_format_lwt.IO)
+
+open Lwt.Infix
+
+type extent = {
+  flags : int32;
+  length : int64;
+} [@@deriving rpc]
+
+(* The flags returned for the base:allocation NBD metadata context are defined here:
+   https://github.com/NetworkBlockDevice/nbd/blob/extension-blockstatus/doc/proto.md#baseallocation-metadata-context *)
+let flag_hole = 1l
+let flag_zero = 2l
+type extent_list = extent list [@@deriving rpc]
+
+let get_extents_json ~server ~export_name =
+  let extent_reader = "/opt/xensource/libexec/get_nbd_extents.py" in
+  Lwt_process.pread
+    ("", [|extent_reader; "--path"; server; "--exportname"; export_name|])
+
+let raw : Vhd_format_lwt.IO.fd -> string -> string -> Vhd_format_lwt.IO.fd F.stream Lwt.t = fun raw server export_name ->
+  get_extents_json ~server ~export_name >>= fun extents_json ->
+  let extents = extent_list_of_rpc (Jsonrpc.of_string extents_json) in
+  let to_sectors b = Int64.div b 512L in
+  let is_empty e =
+    let has_flag flag =
+      Int32.logand e.flags flag = flag
+    in
+    (* We assume the destination is prezeroed, so we do not have to copy zeroed extents *)
+    (has_flag flag_hole) || (has_flag flag_zero)
+  in
+  let assert_integer_sectors b =
+    if Int64.rem b 512L <> 0L then failwith "Expecting sector aligned extents"
+  in
+  let rec operations extents offset acc =
+    match extents with
+    | e::es ->
+      assert_integer_sectors e.length;
+      let op =
+        if is_empty e
+        then `Empty (to_sectors e.length)
+        else `Copy (raw, to_sectors offset, to_sectors e.length)
+      in
+      operations es (Int64.add offset e.length) (op::acc)
+    | [] -> List.rev acc
+  in
+  let ops = operations extents 0L [] in
+  let total = List.fold_left (fun acc e -> Int64.add acc e.length) 0L extents in
+
+  let rec block ops =
+    match ops with
+    | [] -> Lwt.return F.End
+    | op::ops -> Lwt.return (F.Cons (op, fun () -> block ops))
+  in
+  block ops >>= fun elements ->
+  let size = Vhd_format.F.{ total; metadata = 0L; empty = 0L; copy = 0L } in
+  Lwt.return F.{elements; size}

--- a/test/dummy_extent_reader.py
+++ b/test/dummy_extent_reader.py
@@ -1,5 +1,9 @@
 #!/usr/bin/python
 
+"""
+Dummy extent reader that returns a huge extent list
+"""
+
 import json
 
 # We simulate a 4 TiB disk
@@ -10,11 +14,12 @@ DUMMY_DISK_SIZE = 4 * 1024 * 1024 * 1024 * 1024
 # qcow images.
 BLOCK_SIZE = 64 * 1024
 
-def main():
-    extents = []
-    for offset in range(0, DUMMY_DISK_SIZE, BLOCK_SIZE * 2):
-        extents += [{'flags': 0, 'length': BLOCK_SIZE}]
+def _main():
+    extents = [
+        {'flags': 0, 'length': BLOCK_SIZE}
+        for _offset in xrange(0, DUMMY_DISK_SIZE, BLOCK_SIZE * 2)
+    ]
     print json.dumps(extents)
 
 if __name__ == '__main__':
-    main()
+    _main()

--- a/test/dummy_extent_reader.py
+++ b/test/dummy_extent_reader.py
@@ -1,0 +1,20 @@
+#!/usr/bin/python
+
+import json
+
+# We simulate a 4 TiB disk
+DUMMY_DISK_SIZE = 4 * 1024 * 1024 * 1024 * 1024
+
+# Every second 64 KiB block in the disk will be allocated to get a large extent
+# list. This is the granularity at which QEMU 2.12 reports allocated blocks for
+# qcow images.
+BLOCK_SIZE = 64 * 1024
+
+def main():
+    extents = []
+    for offset in range(0, DUMMY_DISK_SIZE, BLOCK_SIZE * 2):
+        extents += [{'flags': 0, 'length': BLOCK_SIZE}]
+    print json.dumps(extents)
+
+if __name__ == '__main__':
+    main()

--- a/test/jbuild
+++ b/test/jbuild
@@ -1,0 +1,12 @@
+(executable
+ ((name suite)
+  (libraries
+   (alcotest
+    alcotest-lwt
+    local_lib))
+  ))
+
+(alias
+ ((name   runtest)
+  (deps   (suite.exe))
+  (action (run ${<}))))

--- a/test/suite.ml
+++ b/test/suite.ml
@@ -1,0 +1,17 @@
+
+open Lwt.Infix
+
+let test_huge_input switch () =
+  let raw = `anything in
+  let server = "" in
+  let export_name = "" in
+  Nbd_input.raw ~extent_reader:"../../../test/dummy_extent_reader.py" raw server export_name >>= fun _ ->
+  Lwt.return_unit
+
+let test_set =
+  let t = Alcotest_lwt.test_case in
+  [ t "VDI with a large allocated extent list" `Quick test_huge_input ]
+
+let () =
+  Alcotest.run "suite"
+    [ "Nbd_input", test_set ]

--- a/vhd-tool.opam
+++ b/vhd-tool.opam
@@ -11,6 +11,8 @@ tags: [
 build: [[ "jbuilder" "build" "-p" name "-j" jobs ]
 ]
 depends: [
+  "alcotest" {test}
+  "alcotest-lwt" {test}
   "base-threads"
   "cmdliner"
   "jbuilder" {build & >= "1.0+beta10"}


### PR DESCRIPTION
Merge with https://github.com/xapi-project/xen-api/pull/3581

When we recognize an NBD device:
1. We look up the path to the Unix domain socket of the corresponding
   NBD server from the file written by nbd_client_manager.py (from the
   xen-api repo)
2. Then we call out to the get_nbd_extents.py
   script, which uses the BLOCK_STATUS NBD extension, introduced in QEMU
   2.12, to query the list of extents and their block status flags.
3. We construct from the returned JSON a structure that sparse_dd
   already understands and can handle.

Signed-off-by: Gabor Igloi <gabor.igloi@citrix.com>

Questions:

- [ ] The license header of `python_nbd_client.py` - it was originally from a BSD repo but has been massively rewritten since then
- [ ] Formatting of class attributes in docstrings in `python_nbd_client.py`:
     ```
    """
    The NBD server replied with an error to the option sent by the client.

    :attribute reply: The error reply sent by the server.
    """
    ```