### PR TITLE
Fix stress test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,9 @@ release:
 test:
 	jbuilder runtest
 
+stresstest:
+	jbuilder build @stresstest
+
 install:
 	jbuilder install
 

--- a/test/jbuild
+++ b/test/jbuild
@@ -1,5 +1,5 @@
 (executable
- ((name suite)
+ ((name stress)
   (libraries
    (alcotest
     alcotest-lwt
@@ -7,6 +7,6 @@
   ))
 
 (alias
- ((name   runtest)
-  (deps   (suite.exe))
+ ((name   stresstest)
+  (deps   (stress.exe (files_recursively_in .)))
   (action (run ${<}))))

--- a/test/stress.ml
+++ b/test/stress.ml
@@ -5,7 +5,7 @@ let test_huge_input switch () =
   let raw = `anything in
   let server = "" in
   let export_name = "" in
-  Nbd_input.raw ~extent_reader:"../../../test/dummy_extent_reader.py" raw server export_name >>= fun _ ->
+  Nbd_input.raw ~extent_reader:"./dummy_extent_reader.py" raw server export_name >>= fun _ ->
   Lwt.return_unit
 
 let test_set =
@@ -13,5 +13,5 @@ let test_set =
   [ t "VDI with a large allocated extent list" `Quick test_huge_input ]
 
 let () =
-  Alcotest.run "suite"
+  Alcotest.run "stress test"
     [ "Nbd_input", test_set ]


### PR DESCRIPTION
- Use @edvintorok's fixes to ensure the python file is always found, no
  matter how we run the tests.
- Make sure this stress test does not run as part of the unit test
  suite, because it's currently very slow and needs 16GB memory.
  It can be run with "make stresstest".

Signed-off-by: Gabor Igloi <gabor.igloi@citrix.com>