### PR TITLE
Make safe-string compliant

### DIFF
--- a/cli/sparse_dd.ml
+++ b/cli/sparse_dd.ml
@@ -303,9 +303,9 @@ let _ =
 
 	let common = Common.make true false true vhd_search_path in
 
-        if !experimental_reads_bypass_tapdisk
+	if !experimental_reads_bypass_tapdisk
 	then warn "experimental_reads_bypass_tapdisk set: this may cause data corruption";
-        if !experimental_writes_bypass_tapdisk
+	if !experimental_writes_bypass_tapdisk
 	then warn "experimental_writes_bypass_tapdisk set: this may cause data corruption";
 
 	let relative_to = match base_image with
@@ -339,11 +339,12 @@ let _ =
 		end in
 
 	let open Lwt in
-	let stream_t, destination, destination_format = match !experimental_reads_bypass_tapdisk, src, src_image, !experimental_writes_bypass_tapdisk, dest, dest_image with
-        | true, _, Some (`Vhd vhd), true, _, Some (`Vhd vhd') ->
+	let stream_t, destination, destination_format =
+		match !experimental_reads_bypass_tapdisk, src, src_image, !experimental_writes_bypass_tapdisk, dest, dest_image with
+		| true, _, Some (`Vhd vhd), true, _, Some (`Vhd vhd') ->
 		prezeroed := false; (* the physical disk will have vhd metadata and other stuff on it *)
 		info "streaming from vhd %s (relative to %s) to vhd %s" vhd (string_opt relative_to) vhd';
-        	let t = Impl.make_stream common vhd relative_to "vhd" "vhd" in
+		let t = Impl.make_stream common vhd relative_to "vhd" "vhd" in
 		t, "file://" ^ vhd', "vhd"
 	| false, _, _, true, _, _ ->
 		error "Not implemented: writes bypass tapdisk while reads go through tapdisk";
@@ -374,11 +375,11 @@ let _ =
 		t, dest, "raw" in
 
 	progress_cb 0.;
-        let progress total_work work_done =
-          let fraction = Int64.(to_float work_done /. (to_float total_work)) in
-          progress_cb fraction in
-        let t =
-        	stream_t >>= fun s ->
+	let progress total_work work_done =
+		let fraction = Int64.(to_float work_done /. (to_float total_work)) in
+			progress_cb fraction in
+		let t =
+		stream_t >>= fun s ->
 		Impl.write_stream common s destination (Some "none") None !prezeroed progress None !ssl_legacy !good_ciphersuites !legacy_ciphersuites in
 	if destination_format = "vhd"
 	then with_paused_tapdisk dest (fun () -> Lwt_main.run t)

--- a/cli/sparse_dd.ml
+++ b/cli/sparse_dd.ml
@@ -311,6 +311,7 @@ let _ =
 	let relative_to = match base_image with
 	| Some (`Vhd x) -> Some x
 	| Some (`Raw _) -> None
+	| Some (`Nbd _) -> None (* TODO: make delta copies work with NBD, CA-289660 *)
 	| None -> None in
 
 	let rewrite_url device_or_url =

--- a/cli/sparse_dd.ml
+++ b/cli/sparse_dd.ml
@@ -144,14 +144,14 @@ let find_backend_device path =
 		let rdev = (Unix.LargeFile.stat path).Unix.LargeFile.st_rdev in
 		let major = rdev / 256 and minor = rdev mod 256 in
 		let link = Unix.readlink (Printf.sprintf "/sys/dev/block/%d:%d/device" major minor) in
-		match List.rev (Re_str.split (Re_str.regexp_string "/") link) with
+		match List.rev (Re.Str.split (Re.Str.regexp_string "/") link) with
 		| id :: "xen" :: "devices" :: _ when startswith "vbd-" id ->
 			let id = int_of_string (String.sub id 4 (String.length id - 4)) in
 			with_xs (fun xs ->
 				let self = xs.Xs.read "domid" in
 				let backend = xs.Xs.read (Printf.sprintf "device/vbd/%d/backend" id) in
 				let params = xs.Xs.read (Printf.sprintf "%s/params" backend) in
-				match Re_str.split (Re_str.regexp_string "/") backend with
+				match Re.Str.split (Re.Str.regexp_string "/") backend with
 				| "local" :: "domain" :: bedomid :: _ ->
 					assert (self = bedomid);
 					Some params

--- a/src/channels.ml
+++ b/src/channels.ml
@@ -28,7 +28,7 @@ let _sendfile from_fd to_fd len =
     Lwt.catch
       (fun () -> detach (_sendfile from_fd to_fd) len)
       (function
-        | Unix.(Unix_error (EAGAIN, _, _)) as e when remaining_attempts > 0 ->
+        | Unix.(Unix_error (EAGAIN, _, _)) when remaining_attempts > 0 ->
             Lwt_unix.sleep 0.1 >>= fun () ->
             loop (remaining_attempts - 1)
         | e -> Lwt.fail e

--- a/src/cohttp_unbuffered_io.ml
+++ b/src/cohttp_unbuffered_io.ml
@@ -45,14 +45,14 @@ type conn = Channels.t
 let really_read_into c buf ofs len =
   let tmp = Cstruct.create len in
   c.Channels.really_read tmp >>= fun () ->
-  Cstruct.blit_to_string tmp 0 buf ofs len;
+  Cstruct.blit_to_bytes tmp 0 buf ofs len;
   return ()
 
 let read_http_headers c =
   let buf = Buffer.create 128 in
   (* We can safely read everything up to this marker: *)
   let end_of_headers = "\r\n\r\n" in
-  let tmp = String.make (String.length end_of_headers) '\000' in
+  let tmp = Bytes.make (String.length end_of_headers) '\000' in
   let module Scanner = struct
     type t = {
       marker: string;
@@ -77,15 +77,15 @@ let read_http_headers c =
       really_read_into c tmp 0 safe_to_read >>= fun () ->
 
       for j = 0 to safe_to_read - 1 do
-        Scanner.input marker tmp.[j];
-        Buffer.add_char buf tmp.[j]
+        Scanner.input marker (Bytes.get tmp j);
+        Buffer.add_char buf (Bytes.get tmp j);
       done;
       loop ()
     end else return () in
   loop () >>= fun () ->
   return (Buffer.contents buf)
 
-let crlf = Re_str.regexp_string "\r\n"
+let crlf = Re.Str.regexp_string "\r\n"
 
 (* We assume read_line is only used to read the HTTP header *)
 let rec read_line ic = match ic.header_buffer, ic.header_buffer_idx with
@@ -96,7 +96,7 @@ let rec read_line ic = match ic.header_buffer, ic.header_buffer_idx with
 | Some buf, i when i < (String.length buf) ->
   begin
     try
-      let eol = Re_str.search_forward crlf buf i in
+      let eol = Re.Str.search_forward crlf buf i in
       let line = String.sub buf i (eol - i) in
       ic.header_buffer_idx <- eol + 2;
       return (Some line)
@@ -110,15 +110,15 @@ let read_into_exactly ic buf ofs len =
   return true
 
 let read_exactly ic len =
-  let buf = String.create len in
+  let buf = Bytes.create len in
   read_into_exactly ic buf 0 len >>= function
   | true -> return (Some buf)
   | false -> return None
 
 let read ic n =
-  let buf = String.make n '\000' in
+  let buf = Bytes.make n '\000' in
   really_read_into ic.c buf 0 n >>= fun () ->
-  return buf
+  return (Bytes.unsafe_to_string buf)
 
 let write oc x =
   let buf = Cstruct.create (String.length x) in


### PR DESCRIPTION
This also adds a fix for a non-exhaustive pattern matching when using NBD. I cannot run the stresstest on my machine because I don't have enough ram