### PR TITLE
XSI-19 locate VHD footer based on file size

### DIFF
--- a/cli/get_vhd_vsize.ml
+++ b/cli/get_vhd_vsize.ml
@@ -14,16 +14,19 @@ let get_vhd_vsize filename =
     | End -> return ()
     | Cons (hd, tl) ->
       begin match hd with
-      | Fragment.Footer x ->
-	let size = x.Footer.current_size in
-	Printf.printf "%Ld\n" size;
-	exit 0
-      | _ ->
-	()
+        | Fragment.Footer x ->
+          let size = x.Footer.current_size in
+          Printf.printf "%Ld\n" size;
+          exit 0
+        | _ ->
+          ()
       end;
       tl () >>= fun x ->
-      loop x in
-  openstream (Input.of_fd (Vhd_format_lwt.IO.to_file_descr fd)) >>= fun stream ->
+      loop x
+  in
+  Vhd_format_lwt.IO.get_file_size filename >>= fun file_size ->
+  openstream (Some file_size)
+    (Input.of_fd (Vhd_format_lwt.IO.to_file_descr fd)) >>= fun stream ->
   loop stream >>= fun () -> Vhd_format_lwt.IO.close fd
 
 let _ =

--- a/cli/main.ml
+++ b/cli/main.ml
@@ -187,7 +187,21 @@ let serve_cmd =
   let ignore_checksums =
     let doc = "Do not verify checksums" in
     Arg.(value & flag & info ["ignore-checksums"] ~doc) in
-  Term.(ret(pure Impl.serve $ common_options_t $ source $ source_fd $ source_format $ source_protocol $ destination $ destination_fd $ destination_format $ destination_size $ prezeroed $ progress $ machine $ tar_filename_prefix $ ignore_checksums)),
+  Term.(ret(pure Impl.serve
+            $ common_options_t
+            $ source
+            $ source_fd
+            $ source_format
+            $ source_protocol
+            $ destination
+            $ destination_fd
+            $ destination_format
+            $ destination_size
+            $ prezeroed
+            $ progress
+            $ machine
+            $ tar_filename_prefix
+            $ ignore_checksums)),
   Term.info "serve" ~sdocs:_common_options ~doc ~man
 
 let stream_cmd =

--- a/src/impl.ml
+++ b/src/impl.ml
@@ -108,7 +108,8 @@ let contents common filename =
         end;
         tl () >>= fun x ->
         loop x in
-      openstream (Input.of_fd (Vhd_format_lwt.IO.to_file_descr fd)) >>= fun stream ->
+      Vhd_format_lwt.IO.get_file_size filename >>= fun size ->
+      openstream (Some size) (Input.of_fd (Vhd_format_lwt.IO.to_file_descr fd)) >>= fun stream ->
       loop stream in
     Lwt_main.run t;
     `Ok ()
@@ -481,7 +482,7 @@ let serve_vhd_to_raw total_size c dest prezeroed progress _ _ =
       (match !p with Some p -> p blocks_seen | None -> ());
       tl () >>= loop block_size_sectors_shift this_block blocks_seen
     | Cons (_, tl) -> tl () >>= loop block_size_sectors_shift last_block blocks_seen in
-  openstream c >>= fun stream ->
+  openstream (Some total_size) c >>= fun stream ->
   loop 0 (-1L) 0L stream
 
 let serve_tar_to_raw total_size c dest prezeroed progress expected_prefix ignore_checksums =


### PR DESCRIPTION
I order to locate the footer in a VHD file or stream, the total length
of that file or stream must be known. This commit passes it when it is
known. This depends on a corresponding change in the ocaml-vhd library.
    
* https://github.com/mirage/ocaml-vhd/pull/58

Signed-off-by: Christian Lindig <christian.lindig@citrix.com>
