### PR TITLE
Update get_nbd_extents.py to match latest NBD protocol

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ _build
 .merlin
 config.mk
 *.install
+
+scripts/*.pyc

--- a/scripts/get_nbd_extents.py
+++ b/scripts/get_nbd_extents.py
@@ -5,10 +5,8 @@ Returns a list of extents with their block statuses for an NBD export.
 
 This program uses new NBD capabilities introduced in QEMU 2.12.
 
-It uses the BLOCK_STATUS NBD extension, which is documented here:
-https://github.com/NetworkBlockDevice/nbd/blob/extension-blockstatus/doc/proto.md
-The structured replies functionality that this extension relies on is in the
-main branch of the NBD protocol docs:
+It uses the BLOCK_STATUS NBD extension, which relies on the structured replies
+functionality. These are documented in the NBD protocol docs:
 https://github.com/NetworkBlockDevice/nbd/blob/master/doc/proto.md
 """
 
@@ -47,7 +45,7 @@ def _get_extents(path, exportname, offset, length):
         client.negotiate_structured_reply()
 
         # Select our metadata context. This context is documented at
-        # https://github.com/NetworkBlockDevice/nbd/blob/extension-blockstatus/doc/proto.md#baseallocation-metadata-context
+        # https://github.com/NetworkBlockDevice/nbd/blob/master/doc/proto.md#baseallocation-metadata-context
         context = 'base:allocation'
         selected_contexts = client.set_meta_contexts(exportname, [context])
         assert_protocol(len(selected_contexts) == 1)
@@ -87,11 +85,16 @@ def _get_extents(path, exportname, offset, length):
             # Then process the returned block status info
             assert_protocol(reply['context_id'] == meta_context_id)
             descriptors = reply['descriptors']
-            for descriptor in descriptors:
+            for i, descriptor in enumerate(descriptors):
                 (extent_length, flags) = descriptor
-                yield {'length': extent_length, 'flags': flags}
                 offset += extent_length
-                assert_protocol(offset <= end)
+                if i < len(descriptors) - 1:
+                    # The first N-1 extents must be smaller than the requested length
+                    assert_protocol(offset <= end)
+                else:
+                    # The last extent can exceed the requested length
+                    extent_length = min(extent_length, end - offset)
+                yield {'length': extent_length, 'flags': flags}
 
 
 def _main():
@@ -107,7 +110,10 @@ def _main():
 
     try:
         parser = argparse.ArgumentParser(
-            description="Return a list of extents with their block statuses")
+            description="Return a list of extents with their block statuses. "
+                        "The returned extents are consecutive, non-overlapping, "
+                        "in the correct order starting from the specified offset, "
+                        "and exactly cover the requested area.")
         parser.add_argument(
             '--path',
             required=True,

--- a/scripts/python_nbd_client.py
+++ b/scripts/python_nbd_client.py
@@ -543,7 +543,7 @@ class PythonNbdClient(object):
         view = memoryview(data)
         fields['context_id'] = struct.unpack(">L", view[:4])[0]
         view = view[4:]
-        descriptors = _parse_block_status_descriptors(view)
+        descriptors = list(_parse_block_status_descriptors(view))
         assert_protocol(descriptors)
         fields['descriptors'] = descriptors
 


### PR DESCRIPTION
The protocol has been changed, so that now in the response for
NBD_REPLY_TYPE_BLOCK_STATUS, the last extent can extend beyond the
requested area. The old code would fail with an assertion error in this
case. I've fixed the code to correctly deal with this corner case.

Signed-off-by: Gabor Igloi <gabor.igloi@citrix.com>