### PR TITLE
 CP-29300: Update get_nbd_extents.py to match latest NBD protocol 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ _build
 .merlin
 config.mk
 *.install
+
+scripts/*.pyc

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,8 @@ install:
 script: bash -ex .travis-docker.sh
 env:
   global:
-    - OCAML_VERSION=4.04.2
-    - DISTRO=debian-9
+    - OCAML_VERSION=4.06
+    - DISTRO=centos
     - PACKAGE=vhd-tool
   matrix:
     - BASE_REMOTE=git://github.com/xapi-project/xs-opam

--- a/scripts/python_nbd_client.py
+++ b/scripts/python_nbd_client.py
@@ -543,7 +543,7 @@ class PythonNbdClient(object):
         view = memoryview(data)
         fields['context_id'] = struct.unpack(">L", view[:4])[0]
         view = view[4:]
-        descriptors = _parse_block_status_descriptors(view)
+        descriptors = list(_parse_block_status_descriptors(view))
         assert_protocol(descriptors)
         fields['descriptors'] = descriptors
 


### PR DESCRIPTION
The protocol has been changed, so that now in the response for
NBD_REPLY_TYPE_BLOCK_STATUS, the last extent can extend beyond the
requested area. The old code would fail with an assertion error in this
case. I've fixed the code to correctly deal with this corner case.