### PR TITLE
Cleanup: move to Dune, remove warnings, update Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,13 @@
 language: c
-sudo: false
-services:
-  - docker
-install:
-  - wget https://raw.githubusercontent.com/ocaml/ocaml-ci-scripts/master/.travis-docker.sh
+sudo: required
+service: docker
+install: wget https://raw.githubusercontent.com/ocaml/ocaml-ci-scripts/master/.travis-docker.sh
 script: bash -ex .travis-docker.sh
 env:
   global:
-    - OCAML_VERSION=4.06
-    - DISTRO=centos
-    - PACKAGE=vhd-tool
+    - PACKAGE="vhd-tool"
+    - PINS="vhd-tool:."
+    - BASE_REMOTE="https://github.com/xapi-project/xs-opam.git"
   matrix:
-    - BASE_REMOTE=git://github.com/xapi-project/xs-opam
-    - EXTRA_REMOTES=git://github.com/xapi-project/xs-opam
-matrix:
-  fast_finish: true
-  allow_failures:
-    - env: EXTRA_REMOTES=git://github.com/xapi-project/xs-opam
+    - DISTRO="debian-9-ocaml-4.06"
+      # - DISTRO="debian-9-ocaml-4.07" BASE_REMOTE_BRANCH="407"

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,10 @@
 .PHONY: build release lint test install uninstall clean reindent
 
-build:
-	jbuilder build @install
-
 release:
-	jbuilder build @install
+	dune build @install
+
+build:
+	dune build @install
 
 lint:
 	pycodestyle scripts/*.py
@@ -12,19 +12,19 @@ lint:
 	pylint --disable fixme,too-many-arguments,too-many-instance-attributes scripts/python_nbd_client.py
 
 test: lint
-	jbuilder runtest
+	dune runtest
 
 stresstest:
-	jbuilder build @stresstest
+	dune build @stresstest
 
 install:
-	jbuilder install
+	dune install
 
 uninstall:
-	jbuilder uninstall
+	dune uninstall
 
 clean:
-	jbuilder clean
+	dune clean
 
 reindent:
 	ocp-indent --inplace **/*.ml*

--- a/cli/get_vhd_vsize.ml
+++ b/cli/get_vhd_vsize.ml
@@ -1,7 +1,5 @@
-open Lwt
 
 module Impl = Vhd_format.F.From_file(Vhd_format_lwt.IO)
-open Impl
 open Vhd_format.F
 open Vhd_format_lwt.IO
 

--- a/cli/main.ml
+++ b/cli/main.ml
@@ -14,7 +14,6 @@
 
 let project_url = "http://github.com/djs55/ocaml-vhd"
 
-open Common
 open Cmdliner
 
 (* Help sections common to all commands *)

--- a/cli/sparse_dd.ml
+++ b/cli/sparse_dd.ml
@@ -165,7 +165,7 @@ let with_paused_tapdisk path f =
 
 	let context = Tapctl.create () in
 	match Tapctl.of_device context path with
-	| tapdev, _, (Some (driver, path)) ->
+	| tapdev, _, (Some (_driver, path)) ->
 		debug "pausing tapdisk for %s" path;
 		Tapctl.pause context tapdev;
 		after f (fun () ->

--- a/src/cohttp_unbuffered_io.ml
+++ b/src/cohttp_unbuffered_io.ml
@@ -15,8 +15,6 @@
  *
  *)
 
-open Lwt
-
 type 'a t = 'a Lwt.t
 let iter fn x = Lwt_list.iter_s fn x
 let return = Lwt.return
@@ -125,5 +123,5 @@ let write oc x =
   Cstruct.blit_from_string x 0 buf 0 (String.length x);
   oc.Channels.really_write buf
 
-let flush oc =
+let flush _oc =
   return ()

--- a/src/iO.ml
+++ b/src/iO.ml
@@ -15,8 +15,6 @@
  *
  *)
 
-open Lwt
-
 let debug_io = ref false
 
 let complete name offset op fd buffer =

--- a/src/jbuild
+++ b/src/jbuild
@@ -4,7 +4,7 @@
   (name local_lib)
   (wrapped false)
   (c_names (sendfile64_stubs))
-  (flags (:standard -w -34-32))
+  (flags (:standard -w -34-32-39))
   (libraries (
     cohttp-lwt
     cstruct

--- a/vhd-tool.opam
+++ b/vhd-tool.opam
@@ -8,28 +8,24 @@ tags: [
   "org:mirage"
   "org:xapi-project"
 ]
-build: [[ "jbuilder" "build" "-p" name "-j" jobs ]
+build: [[ "dune" "build" "-p" name "-j" jobs ]
 ]
 depends: [
-  "alcotest" {test}
-  "alcotest-lwt" {test}
-  "base-threads"
-  "cmdliner"
-  "jbuilder" {build & >= "1.0+beta10"}
-  "cohttp" {>= "0.22.0"}
-  "cohttp-lwt" {>= "0.22.0"}
-  "cstruct" {>= "3.0.0"}
-  "io-page-unix"
-  "lwt" {>= "3.0.0"}
+  "dune" {build}
+
+  "cohttp-lwt"
+  "cstruct"
+  "io-page"
+  "lwt"
   "nbd-lwt-unix"
+  "ocaml-migrate-parsetree"
+  "ppx_deriving_rpc"
   "re"
+  "rpclib"
   "sha"
-  "ssl"
-  "tar-unix"
-  "uri"
-  "vhd-format" {>= "0.7.0"}
+  "tar"
+  "vhd-format"
   "vhd-format-lwt"
-  "xapi-idl"
   "xapi-tapctl"
   "xenstore"
   "xenstore_transport"


### PR DESCRIPTION
This moves the build to using Dune and removes warnings that are triggered by its stricter rules. It also updates the Travis setup.
