### PR TITLE
CA-309290 Catch EOF on read

### DIFF
--- a/src/direct_copy_stubs.c
+++ b/src/direct_copy_stubs.c
@@ -134,7 +134,9 @@ CAMLprim value stub_direct_copy(value handle, value len){
     ssize_t bread;
     ssize_t bwritten = 0;
 
-    bread = read(cpinfo->in_fd, cpinfo->buffer, (remaining < XFER_BUFSIZ)?remaining:XFER_BUFSIZ) ;
+    bread = read(cpinfo->in_fd, cpinfo->buffer, (remaining < XFER_BUFSIZ)?remaining:XFER_BUFSIZ);
+    /* If we previously hit exactly the end of the input by accident, we're done. */
+    if (bread == 0) break;
     if (bread < 0) {
         rc = READ_FAILED;
         goto fail;


### PR DESCRIPTION
If we got an unexpected EOF on read, we would enter an infinite loop
here.

Signed-off-by: Tim Smith <tim.smith@citrix.com>