### PR TITLE
CP-30756: cstruct >= 3.0.0 compatibility

### DIFF
--- a/src/dune
+++ b/src/dune
@@ -22,5 +22,5 @@
     xenstore_transport
     xenstore_transport.unix
   )
-  (preprocess (pps ppx_deriving_rpc cstruct.ppx))
+  (preprocess (pps ppx_deriving_rpc ppx_cstruct))
 )

--- a/vhd-tool.opam
+++ b/vhd-tool.opam
@@ -14,11 +14,12 @@ depends: [
   "ocaml"
   "dune" {build}
   "cohttp-lwt"
-  "cstruct"
+  "cstruct" {>= "3.0.0"}
   "io-page"
   "lwt"
   "nbd-lwt-unix"
   "ocaml-migrate-parsetree"
+  "ppx_cstruct"
   "ppx_deriving_rpc"
   "re"
   "rpclib"


### PR DESCRIPTION
compatibility shims with cstruct 2.* got removed in 3.4.0, bu changing the new modules we're compatible with the lastest version of cstruct