### PR TITLE
Small build fixes for upcoming package updates

### DIFF
--- a/cli/dune
+++ b/cli/dune
@@ -19,7 +19,7 @@
   (targets sparse_dd.1)
   (deps (:x sparse_dd.exe))
   (action (
-    with-stdout-to %{targets} (run %{x} --help=groff)
+    with-stdout-to %{targets} (run %{x} --help)
   ))
 )
 

--- a/src/dune
+++ b/src/dune
@@ -22,5 +22,5 @@
     xenstore_transport
     xenstore_transport.unix
   )
-  (preprocess (pps ppx_deriving_rpc cstruct.ppx))
+  (preprocess (pps ppx_deriving_rpc ppx_cstruct))
 )


### PR DESCRIPTION
When I did a full opam upgrade vhd-tool failed to build due to some deprecations and more strict checks.
This should be backwards compatible with current xs-opam 4.07.1 and my future 4.08 branch too.