### PR TITLE
CP-32843 drop legacy ssl support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,12 @@
 language: c
-sudo: required
 service: docker
-install: wget https://raw.githubusercontent.com/ocaml/ocaml-ci-scripts/master/.travis-docker.sh
+install:
+  - wget https://raw.githubusercontent.com/ocaml/ocaml-ci-scripts/master/.travis-docker.sh
+  - wget https://raw.githubusercontent.com/xapi-project/xs-opam/master/tools/xs-opam-ci.env
+  - source xs-opam-ci.env
 script: bash -ex .travis-docker.sh
 env:
   global:
-    - PACKAGE="vhd-tool"
     - PINS="vhd-tool:."
-    - BASE_REMOTE="https://github.com/xapi-project/xs-opam.git"
-  matrix:
-    - DISTRO="debian-9-ocaml-4.07"
+  jobs:
+    - PACKAGE="vhd-tool"

--- a/cli/main.ml
+++ b/cli/main.ml
@@ -190,17 +190,9 @@ let tar_filename_prefix =
   let doc = "Filename prefix for tar/sha disk blocks" in
   Arg.(value & opt (some string) None & info ["tar-filename-prefix"] ~doc)
 
-let ssl_legacy =
-  let doc = "For TLS, allow all protocol versions instead of just TLSv1.2" in
-  Arg.(value & flag & info ["ssl-legacy"] ~doc)
-
 let good_ciphersuites =
   let doc = "The list of ciphersuites to allow for TLS" in
   Arg.(value & opt (some string) None & info ["good-ciphersuites"] ~doc)
-
-let legacy_ciphersuites =
-  let doc = "Additional TLS ciphersuites allowed only if ssl-legacy is set" in
-  Arg.(value & opt (some string) None & info ["legacy-ciphersuites"] ~doc)
 
 let serve_cmd =
   let doc = "serve the contents of a disk" in
@@ -328,8 +320,7 @@ let stream_cmd =
       pure StreamCommon.make $ source $ relative_to $ source_format
       $ destination_format $ destination $ destination_fd $ source_protocol
       $ destination_protocol $ prezeroed $ progress $ machine
-      $ tar_filename_prefix $ ssl_legacy $ good_ciphersuites
-      $ legacy_ciphersuites)
+      $ tar_filename_prefix $ good_ciphersuites)
   in
   ( Term.(ret (pure Impl.stream $ common_options_t $ stream_args_t))
   , Term.info "stream" ~sdocs:_common_options ~doc ~man )

--- a/cli/sparse_dd.ml
+++ b/cli/sparse_dd.ml
@@ -459,7 +459,7 @@ let _ =
     stream_t
     >>= fun s ->
     Impl.write_stream common s destination (Some "none") None !prezeroed
-      progress None !ssl_legacy !good_ciphersuites !legacy_ciphersuites
+      progress None !good_ciphersuites
   in
   if destination_format = "vhd" then
     with_paused_tapdisk dest (fun () -> Lwt_main.run t)

--- a/src/channels.ml
+++ b/src/channels.ml
@@ -153,21 +153,14 @@ let of_seekable_fd fd =
 let _ =
   Ssl.init ()
 
-let legacy_sslctx good_ciphersuites legacy_ciphersuites =
-  let ctx = Ssl.create_context Ssl.SSLv23 Ssl.Client_context in
-  Ssl.set_cipher_list ctx (good_ciphersuites ^ (match legacy_ciphersuites with "" -> "" | s -> (":" ^ s)));
-  Ssl.disable_protocols ctx [Ssl.SSLv3];
-  ctx
-
-let good_sslctx good_ciphersuites =
+let sslctx good_ciphersuites =
   let ctx = Ssl.create_context Ssl.TLSv1_2 Ssl.Client_context in
   Ssl.set_cipher_list ctx good_ciphersuites;
   ctx
 
-let of_ssl_fd fd ssl_legacy good_ciphersuites legacy_ciphersuites =
+let of_ssl_fd fd good_ciphersuites =
   let good_ciphersuites = match good_ciphersuites with None -> failwith "good_ciphersuites not specified" | Some x -> x in
-  let legacy_ciphersuites = match legacy_ciphersuites with None -> "" | Some x -> x in
-  let sslctx = if ssl_legacy then legacy_sslctx good_ciphersuites legacy_ciphersuites else good_sslctx good_ciphersuites in
+  let sslctx = sslctx good_ciphersuites in
   Lwt_ssl.ssl_connect fd sslctx >>= fun sock ->
   let offset = ref 0L in
   let really_read buf =

--- a/src/impl.ml
+++ b/src/impl.ml
@@ -682,7 +682,7 @@ let make_stream common source relative_to source_format destination_format =
     Raw_input.raw t
   | _, _ -> assert false
 
-let write_stream common s destination _source_protocol destination_protocol prezeroed progress tar_filename_prefix ssl_legacy good_ciphersuites legacy_ciphersuites =
+let write_stream common s destination _source_protocol destination_protocol prezeroed progress tar_filename_prefix good_ciphersuites =
   endpoint_of_string destination >>= fun endpoint ->
   let use_ssl = match endpoint with Https _ -> true | _ -> false in
   ( match endpoint with
@@ -726,7 +726,7 @@ let write_stream common s destination _source_protocol destination_protocol prez
       >>= fun () ->
 
       let open Cohttp in
-      ( if use_ssl then Channels.of_ssl_fd sock ssl_legacy good_ciphersuites legacy_ciphersuites else Channels.of_raw_fd sock ) >>= fun c ->
+      ( if use_ssl then Channels.of_ssl_fd sock good_ciphersuites else Channels.of_raw_fd sock ) >>= fun c ->
 
       let module Request = Request.Make(Cohttp_unbuffered_io) in
       let module Response = Response.Make(Cohttp_unbuffered_io) in
@@ -811,7 +811,7 @@ let write_stream common s destination _source_protocol destination_protocol prez
 
 let stream_t common args ?(progress = no_progress_bar) () =
   make_stream common args.StreamCommon.source args.StreamCommon.relative_to args.StreamCommon.source_format args.StreamCommon.destination_format >>= fun s ->
-  write_stream common s args.StreamCommon.destination args.StreamCommon.source_protocol args.StreamCommon.destination_protocol args.StreamCommon.prezeroed progress args.StreamCommon.tar_filename_prefix args.StreamCommon.ssl_legacy args.StreamCommon.good_ciphersuites args.StreamCommon.legacy_ciphersuites
+  write_stream common s args.StreamCommon.destination args.StreamCommon.source_protocol args.StreamCommon.destination_protocol args.StreamCommon.prezeroed progress args.StreamCommon.tar_filename_prefix args.StreamCommon.good_ciphersuites
 
 let stream common args =
   try

--- a/src/streamCommon.ml
+++ b/src/streamCommon.ml
@@ -41,12 +41,10 @@ type t = {
   progress: bool;
   machine: bool;
   tar_filename_prefix: string option;
-  ssl_legacy: bool;
   good_ciphersuites: string option;
-  legacy_ciphersuites: string option;
 }
 
-let make source relative_to source_format destination_format destination destination_fd source_protocol destination_protocol prezeroed progress machine tar_filename_prefix ssl_legacy good_ciphersuites legacy_ciphersuites =
+let make source relative_to source_format destination_format destination destination_fd source_protocol destination_protocol prezeroed progress machine tar_filename_prefix good_ciphersuites =
   let source_protocol = protocol_of_string (require "source-protocol" source_protocol) in
   let destination_protocol = match destination_protocol with
     | None -> None
@@ -59,5 +57,5 @@ let make source relative_to source_format destination_format destination destina
     | None -> destination
     | Some fd -> "fd://" ^ (string_of_int fd) in
 
-  { source; relative_to; source_format; destination_format; destination; source_protocol; destination_protocol; prezeroed; progress; machine; tar_filename_prefix; ssl_legacy; good_ciphersuites; legacy_ciphersuites }
+  { source; relative_to; source_format; destination_format; destination; source_protocol; destination_protocol; prezeroed; progress; machine; tar_filename_prefix; good_ciphersuites; }
 


### PR DESCRIPTION
Remove ability for client to pass parameters to enable legacy ssl, and
hard code any ssl contexts to TLS v1.2

Signed-off-by: lippirk <ben.anson@citrix.com>