### PR TITLE
CP-35115: If server returns no zeros in its flags, don't wait around

### DIFF
--- a/scripts/get_nbd_extents.py
+++ b/scripts/get_nbd_extents.py
@@ -87,9 +87,9 @@ def _get_extents(path, exportname, offset, length):
             # Note: There might be consecutive descriptors with the same status
             # value.
             descriptors = reply['descriptors']
-            for i, descriptor in enumerate(descriptors):
+            for i, descriptor in enumerate(descriptors, 1):
                 (extent_length, flags) = descriptor
-                if i == extent_length:
+                if i == (len(descriptors)):
                     # The first N-1 extents must be smaller than the requested
                     # length, but the last extent can exceed the requested
                     # length


### PR DESCRIPTION
Fixes some small bugs I noticed when adding nbd extents capabilities to blktap.

These changes can be added independently to the blktap work.

This has gone through a storage bst 139839 and has also gone through the sparse_dd_coalesce.seq JobID:3064205 

Signed-off-by: ben sims <ben.sims@citrix.com>